### PR TITLE
feat(dts): export typescript definitions

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -9,38 +9,81 @@ var concat = require('gulp-concat');
 var insert = require('gulp-insert');
 var rename = require('gulp-rename');
 var tools = require('aurelia-tools');
-var del = require('del');
-var vinylPaths = require('vinyl-paths');
+var gulpIgnore = require('gulp-ignore');
 
 var jsName = paths.packageName + '.js';
 
+function removeDTSPlugin(options) {
+  var found = options.plugins.find(function(x){
+    return x instanceof Array;
+  });
+
+  var index = options.plugins.indexOf(found);
+  options.plugins.splice(index, 1);
+  return options;
+}
+
+gulp.task('build-index', function(){
+  var importsToAdd = [];
+
+  return gulp.src(paths.source)
+    .pipe(tools.sortFiles())
+    .pipe(gulpIgnore.exclude('aurelia-validatejs.js'))
+    .pipe(gulpIgnore.exclude('index.js'))
+    .pipe(through2.obj(function(file, enc, callback) {
+      file.contents = new Buffer(tools.extractImports(file.contents.toString("utf8"), importsToAdd));
+      this.push(file);
+      return callback();
+    }))
+    .pipe(concat(jsName))
+    .pipe(insert.transform(function(contents) {
+      return tools.createImportBlock(importsToAdd) + contents;
+    }))
+    .pipe(gulp.dest(paths.output));
+});
+
+gulp.task('build-es2015-temp', function () {
+    return gulp.src(paths.output + jsName)
+      .pipe(to5(assign({}, compilerOptions.commonjs())))
+      .pipe(gulp.dest(paths.output + 'temp'));
+});
+
 gulp.task('build-es2015', function () {
   return gulp.src(paths.source)
-    .pipe(to5(assign({}, compilerOptions.es2015())))
+    .pipe(to5(assign({}, removeDTSPlugin(compilerOptions.es2015()))))
     .pipe(gulp.dest(paths.output + 'es2015'));
 });
 
 gulp.task('build-commonjs', function () {
   return gulp.src(paths.source)
-    .pipe(to5(assign({}, compilerOptions.commonjs())))
+    .pipe(to5(assign({}, removeDTSPlugin(compilerOptions.commonjs()))))
     .pipe(gulp.dest(paths.output + 'commonjs'));
 });
 
 gulp.task('build-amd', function () {
   return gulp.src(paths.source)
-    .pipe(to5(assign({}, compilerOptions.amd())))
+    .pipe(to5(assign({}, removeDTSPlugin(compilerOptions.amd()))))
     .pipe(gulp.dest(paths.output + 'amd'));
 });
 
 gulp.task('build-system', function () {
   return gulp.src(paths.source)
-    .pipe(to5(assign({}, compilerOptions.system())))
+    .pipe(to5(assign({}, removeDTSPlugin(compilerOptions.system()))))
     .pipe(gulp.dest(paths.output + 'system'));
+});
+
+gulp.task('build-dts', function(){
+  return gulp.src(paths.output + paths.packageName + '.d.ts')
+      .pipe(rename(paths.packageName + '.d.ts'))
+      .pipe(gulp.dest(paths.output + 'es2015'))
+      .pipe(gulp.dest(paths.output + 'commonjs'))
+      .pipe(gulp.dest(paths.output + 'amd'))
+      .pipe(gulp.dest(paths.output + 'system'));
 });
 
 gulp.task('build-sample', ['build-sample-html'], function () {
   return gulp.src(paths.sample + '/src/**/*.js')
-    .pipe(to5(assign({}, compilerOptions.amd())))
+    .pipe(to5(assign({}, removeDTSPlugin(compilerOptions.amd()))))
     .pipe(gulp.dest(paths.sample + '/dist'));
 });
 gulp.task('build-sample-html', function () {
@@ -51,7 +94,10 @@ gulp.task('build-sample-html', function () {
 gulp.task('build', function(callback) {
   return runSequence(
     'clean',
-    ['build-es2015', 'build-commonjs', 'build-amd', 'build-system'],
+    'build-index',
+    ['build-es2015-temp', 'build-es2015', 'build-commonjs', 'build-amd', 'build-system'],
+    'build-dts',
+    'clean-temp',
     callback
   );
 });

--- a/build/tasks/clean.js
+++ b/build/tasks/clean.js
@@ -7,3 +7,8 @@ gulp.task('clean', function() {
   return gulp.src([paths.output])
     .pipe(vinylPaths(del));
 });
+
+gulp.task('clean-temp', function() {
+  return gulp.src([paths.output + '/temp'])
+    .pipe(vinylPaths(del));
+});

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "gulp-bump": "^0.1.11",
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^1.0.0",
+    "gulp-ignore": "^2.0.1",
     "gulp-insert": "^0.5.0",
     "gulp-rename": "^1.2.2",
     "gulp-typedoc": "^1.2.1",

--- a/sample/config.js
+++ b/sample/config.js
@@ -196,8 +196,12 @@ System.config({
       "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0"
     },
     "npm:aurelia-validation@0.8.0": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.4",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.2",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0"
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.5"
     },
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"

--- a/sample/index.html
+++ b/sample/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Aurelia</title>
-    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.6.1/css/font-awesome.min.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body aurelia-app="dist/main">

--- a/sample/package.json
+++ b/sample/package.json
@@ -23,6 +23,7 @@
       "aurelia-templating-binding": "npm:aurelia-templating-binding@^1.0.0-beta.1.1.0",
       "aurelia-templating-resources": "npm:aurelia-templating-resources@^1.0.0-beta.1.1.0",
       "aurelia-templating-router": "npm:aurelia-templating-router@^1.0.0-beta.1.1.0",
+      "aurelia-validation": "npm:aurelia-validation@0.8.0",
       "font-awesome": "npm:font-awesome@^4.4.0",
       "twbs/bootstrap": "github:twbs/bootstrap@3.3.5",
       "validate.js": "npm:validate.js@^0.9.0"

--- a/src/base-decorator.js
+++ b/src/base-decorator.js
@@ -1,7 +1,7 @@
 import {metadata} from 'aurelia-metadata';
 import {ValidationConfig} from './validation-config';
 import {ValidationEngine} from './validation-engine';
-import {validationMetadataKey} from 'aurelia-validation';
+import {validationMetadataKey} from './metadata-key';
 
 export function base(targetOrConfig, key, descriptor, Rule) {
   let deco = function(target, key2, descriptor2) {

--- a/src/validate-binding-behavior.js
+++ b/src/validate-binding-behavior.js
@@ -1,8 +1,9 @@
 // import {ValidationEngine} from './validation-engine';
 import {ValidationRenderer} from './validation-renderer';
+import {inject} from 'aurelia-dependency-injection';
 
+@inject(ValidationRenderer)
 export class ValidateBindingBehavior {
-  static inject = [ValidationRenderer];
   constructor(renderer) {
     this.renderer = renderer;
   }

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,4 +1,4 @@
-import {validationMetadataKey} from 'aurelia-validation';
+import {validationMetadataKey} from './metadata-key';
 import {ValidationConfig} from './validation-config';
 import {ValidationEngine} from './validation-engine';
 import {ValidationRule} from './validation-rule';


### PR DESCRIPTION
closes https://github.com/aurelia/validatejs/issues/8

I had to make a few changes in order to get the d.ts to generate:

1. use @inject instead of static inject   (https://github.com/aurelia/validatejs/pull/32/commits/b1dcb6eb3f116716d750c11d2bf69a541ebbfad0#diff-fa04c34385d93f388685f83022383370R3) fixed this error:
    ```
    SyntaxError: D:/Development/validatejs/dist/aurelia-validatejs.js: The keyword static' is reserved (236:2)
      234 |
      235 | // export class ValidateBindingBehavior {
    > 236 |   static inject = [ValidationRenderer];
          |   ^
      237 |   constructor(renderer) {
      238 |     this.renderer = renderer;
      239 |   }
        at Parser.pp.raise (D:\Development\validatejs\node_modules\gulp-babel\node_odules\babylon\lib\parser\location.js:22:13)
        at Parser.pp.parseIdentifier (D:\Development\validatejs\node_modules\gulp-bbel\node_modules\babylon\lib\parser
    
    \expression.js:1046:12)
        at Parser.pp.parseExprAtom (D:\Development\validatejs\node_modules\gulp-babl\node_modules\babylon\lib\parser
    
    \expression.js:413:21)
        at Parser.pp.parseExprSubscripts (D:\Development\validatejs\node_modules\gup-babel\node_modules\babylon\lib\parser
    
    \expression.js:272:19)
        at Parser.pp.parseMaybeUnary (D:\Development\validatejs\node_modules\gulp-bbel\node_modules\babylon\lib\parser
    
    \expression.js:252:19)
        at Parser.pp.parseExprOps (D:\Development\validatejs\node_modules\gulp-babe\node_modules\babylon\lib\parser
    
    \expression.js:183:19)
        at Parser.pp.parseMaybeConditional (D:\Development\validatejs\node_modules\ulp-babel\node_modules\babylon\lib\parser
    
    \expression.js:165:19)
        at Parser.pp.parseMaybeAssign (D:\Development\validatejs\node_modules\gulp-abel\node_modules\babylon\lib\parser
    
    \expression.js:128:19)
        at Parser.pp.parseExpression (D:\Development\validatejs\node_modules\gulp-bbel\node_modules\babylon\lib\parser
    
    \expression.js:92:19)
        at Parser.pp.parseStatement (D:\Development\validatejs\node_modules\gulp-bael\node_modules\babylon\lib\parser
    
    \statement.js:163:19)
        at Parser.parseStatement (D:\Development\validatejs\node_modules\gulp-babelnode_modules\babylon\lib\plugins\flow.js:30:22)
        at Parser.pp.parseBlockBody (D:\Development\validatejs\node_modules\gulp-bael\node_modules\babylon\lib\parser
    
    \statement.js:529:21)
        at Parser.pp.parseTopLevel (D:\Development\validatejs\node_modules\gulp-babl\node_modules\babylon\lib\parser\statement.js:36:8)
        at Parser.parse (D:\Development\validatejs\node_modules\gulp-babel\node_modles\babylon\lib\parser\index.js:129:19)
        at parse (D:\Development\validatejs\node_modules\gulp-babel\node_modules\baylon\lib\index.js:47:47)
        at File.parse (D:\Development\validatejs\node_modules\gulp-babel\node_moduls\babel-core\lib\transformation\file\index.js:540:58)
    ```


2. import validationMetadataKey from a single location (https://github.com/aurelia/validatejs/pull/32/commits/b1dcb6eb3f116716d750c11d2bf69a541ebbfad0#diff-bc76beef7b3925bf795ee775519e75cdR1 and https://github.com/aurelia/validatejs/pull/32/commits/b1dcb6eb3f116716d750c11d2bf69a541ebbfad0#diff-dd24c6ebcf47fc528d32109610336526R4)
    ```
    TypeError: D:/Development/validatejs/dist/aurelia-validatejs.js: Duplicate declaration "validationMetadataKey"
      55 | }
      56 |
    > 57 | export const validationMetadataKey = 'aurelia:validation';
         |              ^
      58 |
      59 | function getRandomId() {
      60 |   let rand = Math.floor(Math.random() * (99999 - 10000 + 1)) + 10000;
        at File.buildCodeFrameError (D:\Development\validatejs\node_modules\gulp-babel\node_modules\babel-core\lib\transformation\file
    
    \index.js:467:15)
        at Scope.checkBlockScopedCollisions (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:490:27)
        at Scope.registerBinding (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:679:16)
        at Scope.registerDeclaration (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:578:14)
        at Object.BlockScoped (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:217:28)
        at Object.newFn (D:\Development\validatejs\node_modules\babel-traverse\lib\visitors.js:343:17)
        at NodePath._call (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:78:18)
        at NodePath.call (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:45:14)
        at NodePath.visit (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:108:12)
        at TraversalContext.visitQueue (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:174:16)
        at TraversalContext.visitSingle (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:124:19)
        at TraversalContext.visit (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:219:19)
        at Function.traverse.node (D:\Development\validatejs\node_modules\babel-traverse\lib\index.js:171:17)
        at NodePath.visit (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:118:43)
        at TraversalContext.visitQueue (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:174:16)
        at TraversalContext.visitMultiple (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:119:17)
    ```

3. The error below is caused because the babel-dts-generator doesn't support all those export/import statements in index.js. As the index.js doesn't contain many types (yet), I decided to exclude this from the build-index task ([here](https://github.com/aurelia/validatejs/pull/32/commits/b1dcb6eb3f116716d750c11d2bf69a541ebbfad0#diff-40e62be8220b9aeab02f5a664980bd73R32)).
    ```
    TypeError: D:/Development/validatejs/dist/aurelia-validatejs.js: Duplicate declaration "ValidationReporter"
      74 | }
      75 |
    > 76 | export class ValidationReporter {
         |              ^
      77 |   callback;
      78 |   __callbacks__ = {};
      79 |   subscribe(callback) {
        at File.buildCodeFrameError (D:\Development\validatejs\node_modules\gulp-babel\node_modules\babel-core\lib\transformation\file
    
    \index.js:467:15)
        at Scope.checkBlockScopedCollisions (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:490:27)
        at Scope.registerBinding (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:679:16)
        at Scope.registerDeclaration (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:581:12)
        at Object.BlockScoped (D:\Development\validatejs\node_modules\babel-traverse\lib\scope\index.js:217:28)
        at Object.newFn (D:\Development\validatejs\node_modules\babel-traverse\lib\visitors.js:343:17)
        at NodePath._call (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:78:18)
        at NodePath.call (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:45:14)
        at NodePath.visit (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:108:12)
        at TraversalContext.visitQueue (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:174:16)
        at TraversalContext.visitSingle (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:124:19)
        at TraversalContext.visit (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:219:19)
        at Function.traverse.node (D:\Development\validatejs\node_modules\babel-traverse\lib\index.js:171:17)
        at NodePath.visit (D:\Development\validatejs\node_modules\babel-traverse\lib\path\context.js:118:43)
        at TraversalContext.visitQueue (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:174:16)
        at TraversalContext.visitMultiple (D:\Development\validatejs\node_modules\babel-traverse\lib\context.js:119:17)
    ```



[this is the resulting d.ts file](https://gist.github.com/JeroenVinke/5aee9efd2a9b59b52deb8fa5c40332e7)