### PR TITLE
refactor(validator): pass object for validation into `validate`

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -7,12 +7,12 @@ import {metadata} from 'aurelia-metadata';
 export class Validator {
   object;
   config;
-  validate(prop) {
-    let reporter = ValidationEngine.getValidationReporter(this.object);
+  validate(obj, prop) {
+    let reporter = ValidationEngine.getValidationReporter(obj);
     if (prop) {
-      this.config.validate(this.object, reporter, prop);
+      this.config.validate(obj, reporter, prop);
     } else {
-      this.config.validate(this.object, reporter);
+      this.config.validate(obj, reporter);
     }
   }
   getProperties() {

--- a/test/unit/validator.spec.js
+++ b/test/unit/validator.spec.js
@@ -6,6 +6,7 @@ import {ValidationConfig} from 'src/validation-config';
 import {metadata} from 'aurelia-metadata';
 
 describe('Validator', () => {
+  let injectedValidator;
   let container;
   let validation;
   let reporter;
@@ -15,7 +16,7 @@ describe('Validator', () => {
 
     beforeEach(() => {
       container = new Container();
-      validation = container.get(Validator);
+      injectedValidator = container.get(Validator);
     });
 
     describe('with a single property', () => {
@@ -23,23 +24,21 @@ describe('Validator', () => {
 
         class Target {
           firstName = 'Patrick';
-          constructor() {
-            this.validation =
-              validation.ensure(this, 'firstName')
-                .length({minimum: 3});
-          }
         }
 
         beforeEach(() => {
           target = new Target();
           metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, target);
+          validator = injectedValidator
+              .ensure(target, 'firstName')
+                .length({minimum: 3});
         });
 
         describe('.validate', () => {
           it('runs validation against the correct instance / config', (done) => {
             reporter = ValidationEngine.getValidationReporter(target);
             spyOn(reporter, 'publish');
-            target.validation.validate();
+            validator.validate(target);
             setTimeout(() => {
               expect(reporter.publish).toHaveBeenCalled();
               done();
@@ -54,7 +53,7 @@ describe('Validator', () => {
             reporter = ValidationEngine.getValidationReporter(target);
             spyOn(reporter, 'publish');
             target.firstName = 'no';
-            target.validation.validate();
+            validator.validate(target);
             setTimeout(() => {
               expect(reporter.publish).toHaveBeenCalledWith(expectedResult);
               done();
@@ -75,17 +74,16 @@ describe('Validator', () => {
 
         class Target {
           firstName = 'Patrick';
-          constructor() {
-            this.validation =
-              validation.ensure(this, 'firstName')
-                .numericality()
-                .length({minimum: 3});
-          }
         }
 
         beforeEach(() => {
           target = new Target();
           metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, target);
+
+          validator = injectedValidator
+              .ensure(target, 'firstName')
+                .numericality()
+                .length({minimum: 3});
         });
 
         describe('.validate', () => {
@@ -101,7 +99,7 @@ describe('Validator', () => {
             reporter = ValidationEngine.getValidationReporter(target);
             spyOn(reporter, 'publish');
             target.firstName = 'no';
-            target.validation.validate();
+            validator.validate(target);
             setTimeout(() => {
               expect(reporter.publish).toHaveBeenCalledWith(expectedResult);
               done();
@@ -116,18 +114,17 @@ describe('Validator', () => {
       class Target {
         firstName = 'Patrick';
         lastName = 'Walters';
-        constructor() {
-          this.validation =
-            validation.ensure(this, 'firstName')
-                .length({minimum: 3})
-              .ensure(this, 'lastName')
-                .length({minimum: 3});
-        }
       }
 
       beforeEach(() => {
         target = new Target();
         metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, target);
+
+        validator = injectedValidator
+            .ensure(target, 'firstName')
+              .length({minimum: 3})
+            .ensure(target, 'lastName')
+              .length({minimum: 3});
       });
 
       describe('.validate', () => {
@@ -144,7 +141,7 @@ describe('Validator', () => {
           spyOn(reporter, 'publish');
           target.firstName = 'no';
           target.lastName = 'no';
-          target.validation.validate();
+          validator.validate(target);
           setTimeout(() => {
             expect(reporter.publish).toHaveBeenCalledWith(expectedResult);
             done();
@@ -154,7 +151,7 @@ describe('Validator', () => {
         it('runs validation against the correct instance / config', (done) => {
           reporter = ValidationEngine.getValidationReporter(target);
           spyOn(reporter, 'publish');
-          target.validation.validate();
+          validator.validate(target);
           setTimeout(() => {
             expect(reporter.publish).toHaveBeenCalled();
             done();
@@ -171,25 +168,24 @@ describe('Validator', () => {
 
     class Target {
       model = new TargetModel();
-      constructor() {
-        this.validation =
-          validation.ensure(this.model, 'firstName')
-            .length({minimum: 3});
-      }
     }
 
     beforeEach(() => {
       container = new Container();
-      validation = container.get(Validator);
+      injectedValidator = container.get(Validator);
       target = new Target();
       metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, target.model);
+
+      validator = injectedValidator
+        .ensure(target.model, 'firstName')
+          .length({minimum: 3});
     });
 
     describe('.validate', () => {
       it('runs validation against the correct instance / config', (done) => {
         reporter = ValidationEngine.getValidationReporter(target.model);
         spyOn(reporter, 'publish');
-        target.validation.validate();
+        validator.validate(target.model);
         setTimeout(() => {
           expect(reporter.publish).toHaveBeenCalled();
           done();


### PR DESCRIPTION
This is mostly meant to serve as a basis for conversation about refactorings for the validator in general pairing with this comment: https://github.com/aurelia/validatejs/issues/33#issuecomment-217710788.

As you can see this begins to decouple the validator from the data it is validating. The refactor is incomplete as the metadata is still stored on the model (further changes down this path would have to be discussed), but I think it begins to exemplify what I was talking about in the comment linked above.

Thoughts?