### PR TITLE
refactor: ruleset test

### DIFF
--- a/dist/amd/decorators.js
+++ b/dist/amd/decorators.js
@@ -16,6 +16,7 @@ define(['exports', './validation-rule', './base-decorator'], function (exports, 
   exports.format = format;
   exports.url = url;
   exports.numericality = numericality;
+  exports.custom = custom;
   function length(targetOrConfig, key, descriptor) {
     return (0, _baseDecorator.base)(targetOrConfig, key, descriptor, _validationRule.ValidationRule.lengthRule);
   }
@@ -62,5 +63,13 @@ define(['exports', './validation-rule', './base-decorator'], function (exports, 
 
   function numericality(targetOrConfig, key, descriptor) {
     return (0, _baseDecorator.base)(targetOrConfig, key, descriptor, _validationRule.ValidationRule.numericality);
+  }
+
+  function custom(name, targetOrConfig, key, descriptor) {
+    targetOrConfig = {
+      name: name,
+      config: targetOrConfig === undefined ? true : targetOrConfig
+    };
+    return (0, _baseDecorator.base)(targetOrConfig, key, descriptor, _validationRule.ValidationRule.custom);
   }
 });

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -1,10 +1,10 @@
-define(['exports', './decorators', './validation-engine', './validator', './validation-reporter', './validation-renderer', 'aurelia-validation'], function (exports, _decorators, _validationEngine, _validator, _validationReporter, _validationRenderer, _aureliaValidation) {
+define(['exports', './decorators', './validation-engine', './validator', './validator-lite', './validation-ruleset', './validation-reporter', './validation-renderer', 'aurelia-validation'], function (exports, _decorators, _validationEngine, _validator, _validatorLite, _validationRuleset, _validationReporter, _validationRenderer, _aureliaValidation) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-  exports.ValidationRenderer = exports.ValidationReporter = exports.Validator = exports.ValidationEngine = exports.numericality = exports.url = exports.format = exports.inclusion = exports.exclusion = exports.equality = exports.email = exports.datetime = exports.date = exports.required = exports.length = undefined;
+  exports.ValidationRenderer = exports.ValidationReporter = exports.ValidationRuleset = exports.ValidatorLite = exports.Validator = exports.ValidationEngine = exports.custom = exports.numericality = exports.url = exports.format = exports.inclusion = exports.exclusion = exports.equality = exports.email = exports.datetime = exports.date = exports.required = exports.length = undefined;
   Object.defineProperty(exports, 'length', {
     enumerable: true,
     get: function () {
@@ -71,6 +71,12 @@ define(['exports', './decorators', './validation-engine', './validator', './vali
       return _decorators.numericality;
     }
   });
+  Object.defineProperty(exports, 'custom', {
+    enumerable: true,
+    get: function () {
+      return _decorators.custom;
+    }
+  });
   Object.defineProperty(exports, 'ValidationEngine', {
     enumerable: true,
     get: function () {
@@ -81,6 +87,18 @@ define(['exports', './decorators', './validation-engine', './validator', './vali
     enumerable: true,
     get: function () {
       return _validator.Validator;
+    }
+  });
+  Object.defineProperty(exports, 'ValidatorLite', {
+    enumerable: true,
+    get: function () {
+      return _validatorLite.ValidatorLite;
+    }
+  });
+  Object.defineProperty(exports, 'ValidationRuleset', {
+    enumerable: true,
+    get: function () {
+      return _validationRuleset.ValidationRuleset;
     }
   });
   Object.defineProperty(exports, 'ValidationReporter', {
@@ -99,6 +117,7 @@ define(['exports', './decorators', './validation-engine', './validator', './vali
   function configure(config) {
     config.container.registerHandler(_aureliaValidation.Validator, _validator.Validator);
     config.container.registerHandler(_aureliaValidation.ValidationReporter, _validationReporter.ValidationReporter);
-    config.globalResources('./validate-binding-behavior');
+    config.globalResources('./validation-rendering-binding-behavior');
+    config.globalResources('./live-validation-rendering-binding-behavior');
   }
 });

--- a/dist/amd/live-validation-rendering-binding-behavior.js
+++ b/dist/amd/live-validation-rendering-binding-behavior.js
@@ -1,0 +1,75 @@
+define(['exports', './validation-renderer', 'aurelia-dependency-injection', './validation-engine'], function (exports, _validationRenderer, _aureliaDependencyInjection, _validationEngine) {
+  'use strict';
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.LiveValidationRenderingBindingBehavior = undefined;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  var _dec, _class;
+
+  var LiveValidationRenderingBindingBehavior = exports.LiveValidationRenderingBindingBehavior = (_dec = (0, _aureliaDependencyInjection.inject)(_validationRenderer.ValidationRenderer), _dec(_class = function () {
+    function LiveValidationRenderingBindingBehavior(renderer) {
+      _classCallCheck(this, LiveValidationRenderingBindingBehavior);
+
+      this.renderer = renderer;
+      this.liveBinding = true;
+    }
+
+    LiveValidationRenderingBindingBehavior.prototype.bind = function bind(binding, source) {
+      var _this = this;
+
+      var targetProperty = void 0;
+      var target = void 0;
+      var reporter = void 0;
+
+      binding.target._dirty = false;
+      binding.target.addEventListener('focus', function (event) {
+        binding.target._dirty = true;
+      });
+      targetProperty = this.getTargetProperty(binding);
+      target = this.getTargetObject(binding);
+      reporter = _validationEngine.ValidationEngine.getOrCreateValidationReporter(target);
+      reporter.subscribe(function (errors, pushRendering) {
+        var relevantErrors = errors.filter(function (error) {
+          return error.propertyName === targetProperty;
+        });
+
+        if (_this.liveBinding && binding.target._dirty || pushRendering) _this.renderer.renderErrors(binding.target, relevantErrors);
+      });
+    };
+
+    LiveValidationRenderingBindingBehavior.prototype.unbind = function unbind(binding, source) {};
+
+    LiveValidationRenderingBindingBehavior.prototype.getTargetProperty = function getTargetProperty(binding) {
+      var targetProperty = void 0;
+      if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+        targetProperty = binding.sourceExpression.expression.name;
+      }
+      return targetProperty;
+    };
+
+    LiveValidationRenderingBindingBehavior.prototype.getTargetObject = function getTargetObject(binding) {
+      var targetObject = void 0;
+      if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+        targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+      } else {
+        targetObject = binding.source.bindingContext;
+      }
+      return targetObject;
+    };
+
+    LiveValidationRenderingBindingBehavior.prototype.getPropertyContext = function getPropertyContext(source, targetProperty) {
+      var target = getContextFor(source, targetProperty);
+      return target;
+    };
+
+    return LiveValidationRenderingBindingBehavior;
+  }()) || _class);
+});

--- a/dist/amd/validation-engine.js
+++ b/dist/amd/validation-engine.js
@@ -18,7 +18,16 @@ define(['exports', './validation-reporter'], function (exports, _validationRepor
     }
 
     ValidationEngine.getValidationReporter = function getValidationReporter(instance) {
-      return instance.__validationReporter__ || (instance.__validationReporter__ = new _validationReporter.ValidationReporter());
+      return instance.__validationReporter__;
+    };
+
+    ValidationEngine.ensureValidationReporter = function ensureValidationReporter(instance) {
+      if (!instance.__validationReporter__) instance.__validationReporter__ = new _validationReporter.ValidationReporter();
+    };
+
+    ValidationEngine.getOrCreateValidationReporter = function getOrCreateValidationReporter(instance) {
+      ValidationEngine.ensureValidationReporter(instance);
+      return ValidationEngine.getValidationReporter(instance);
     };
 
     return ValidationEngine;

--- a/dist/amd/validation-renderer.js
+++ b/dist/amd/validation-renderer.js
@@ -19,18 +19,21 @@ define(['exports', 'aurelia-pal'], function (exports, _aureliaPal) {
 
     ValidationRenderer.prototype.renderErrors = function renderErrors(node, relevantErrors) {
       if (relevantErrors.length) {
+        this.unrenderErrors(node);
         node.parentElement.classList.add('has-error');
         relevantErrors.forEach(function (error) {
           if (node.parentElement.textContent.indexOf(error.message) === -1) {
             var errorMessageHelper = _aureliaPal.DOM.createElement('span');
             var errorMessageNode = _aureliaPal.DOM.createTextNode(error.message);
             errorMessageHelper.appendChild(errorMessageNode);
-            errorMessageHelper.classList.add('help-block');
+            errorMessageHelper.classList.add('help-block', 'au-validation');
             node.parentElement.appendChild(errorMessageHelper);
           }
         });
       } else {
-        this.unrenderErrors(node);
+        if (node.parentElement.classList.contains('has-error')) {
+          this.unrenderErrors(node);
+        }
       }
     };
 
@@ -40,7 +43,7 @@ define(['exports', 'aurelia-pal'], function (exports, _aureliaPal) {
       var children = node.parentElement.children;
       for (var i = 0; i < children.length; i++) {
         var child = children[i];
-        if (child.classList.contains('help-block')) {
+        if (child.classList.contains('help-block') && child.classList.contains('au-validation')) {
           deleteThese.push(child);
         }
       }

--- a/dist/amd/validation-rendering-binding-behavior.js
+++ b/dist/amd/validation-rendering-binding-behavior.js
@@ -1,0 +1,73 @@
+define(['exports', './validation-renderer', 'aurelia-dependency-injection', './validation-engine'], function (exports, _validationRenderer, _aureliaDependencyInjection, _validationEngine) {
+  'use strict';
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.ValidationRenderingBindingBehavior = undefined;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  var _dec, _class;
+
+  var ValidationRenderingBindingBehavior = exports.ValidationRenderingBindingBehavior = (_dec = (0, _aureliaDependencyInjection.inject)(_validationRenderer.ValidationRenderer), _dec(_class = function () {
+    function ValidationRenderingBindingBehavior(renderer) {
+      _classCallCheck(this, ValidationRenderingBindingBehavior);
+
+      this.renderer = renderer;
+      this.liveBinding = false;
+    }
+
+    ValidationRenderingBindingBehavior.prototype.bind = function bind(binding, source) {
+      var _this = this;
+
+      var targetProperty = void 0;
+      var target = void 0;
+      var reporter = void 0;
+      source._dirty = false;
+      binding.target.addEventListener('focus', function (event) {
+        source._dirty = true;
+      });
+      targetProperty = this.getTargetProperty(binding);
+      target = this.getTargetObject(binding);
+      reporter = _validationEngine.ValidationEngine.getOrCreateValidationReporter(target);
+      reporter.subscribe(function (errors, pushRendering) {
+        var relevantErrors = errors.filter(function (error) {
+          return error.propertyName === targetProperty;
+        });
+        if (_this.liveBinding && source._dirty || pushRendering) _this.renderer.renderErrors(binding.target, relevantErrors);
+      });
+    };
+
+    ValidationRenderingBindingBehavior.prototype.unbind = function unbind(binding, source) {};
+
+    ValidationRenderingBindingBehavior.prototype.getTargetProperty = function getTargetProperty(binding) {
+      var targetProperty = void 0;
+      if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+        targetProperty = binding.sourceExpression.expression.name;
+      }
+      return targetProperty;
+    };
+
+    ValidationRenderingBindingBehavior.prototype.getTargetObject = function getTargetObject(binding) {
+      var targetObject = void 0;
+      if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+        targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+      } else {
+        targetObject = binding.source.bindingContext;
+      }
+      return targetObject;
+    };
+
+    ValidationRenderingBindingBehavior.prototype.getPropertyContext = function getPropertyContext(source, targetProperty) {
+      var target = getContextFor(source, targetProperty);
+      return target;
+    };
+
+    return ValidationRenderingBindingBehavior;
+  }()) || _class);
+});

--- a/dist/amd/validation-reporter.js
+++ b/dist/amd/validation-reporter.js
@@ -47,7 +47,7 @@ define(["exports"], function (exports) {
       return observer;
     };
 
-    ValidationReporter.prototype.publish = function publish(errors) {
+    ValidationReporter.prototype.publish = function publish(errors, pushRendering) {
       for (var _iterator = Object.keys(this.__callbacks__), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
         var _ref;
 
@@ -63,7 +63,7 @@ define(["exports"], function (exports) {
         var key = _ref;
 
         var observer = this.__callbacks__[key];
-        observer.callback(errors);
+        observer.callback(errors, pushRendering);
       }
     };
 

--- a/dist/amd/validation-rule.js
+++ b/dist/amd/validation-rule.js
@@ -73,6 +73,14 @@ define(['exports', 'validate.js', 'aurelia-validation'], function (exports, _val
     };
 
     ValidationRule.format = function format(config) {
+      if (config instanceof RegExp) {
+        var pattern = config.toString();
+        pattern = pattern.substr(1, pattern.length - 2);
+        config = {
+          pattern: pattern
+        };
+      }
+
       return new ValidationRule('format', config);
     };
 
@@ -100,6 +108,17 @@ define(['exports', 'validate.js', 'aurelia-validation'], function (exports, _val
       var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
       return new ValidationRule('url', config);
+    };
+
+    ValidationRule.custom = function custom() {
+      var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var name = arguments[1];
+
+      if (Reflect.has(config, "name")) {
+        return new ValidationRule(config.name, config.config);
+      } else {
+        return new ValidationRule(name, config);
+      }
     };
 
     return ValidationRule;

--- a/dist/amd/validation-ruleset.js
+++ b/dist/amd/validation-ruleset.js
@@ -1,0 +1,127 @@
+define(['exports', './validation-rule', './validation-engine', 'aurelia-metadata', './metadata-key'], function (exports, _validationRule, _validationEngine, _aureliaMetadata, _metadataKey) {
+  'use strict';
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.ValidationRuleset = undefined;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  var ValidationRuleset = exports.ValidationRuleset = function () {
+    function ValidationRuleset() {
+      _classCallCheck(this, ValidationRuleset);
+
+      this.__validationRules__ = [];
+    }
+
+    ValidationRuleset.for = function _for(object) {
+      return new Validator(object);
+    };
+
+    ValidationRuleset.prototype.addRule = function addRule(key, rule) {
+      this.__validationRules__.push({ key: key, rule: rule });
+    };
+
+    ValidationRuleset.prototype.validate = function validate(instance, property, _pushRendering) {
+      var errors = [];
+
+      var reporter = _validationEngine.ValidationEngine.getValidationReporter(instance);
+      this.__validationRules__.forEach(function (rule) {
+        if (!property || property === rule.key) {
+          var result = rule.rule.validate(instance, rule.key);
+          if (result) {
+            errors.push(result);
+          }
+        }
+      });
+
+      if (reporter) reporter.publish(errors, _pushRendering);
+      return errors;
+    };
+
+    ValidationRuleset.prototype[Symbol.iterator] = function () {
+      return this.__validationRules__[Symbol.iterator]();
+    };
+
+    ValidationRuleset.getDecoratorsRuleset = function getDecoratorsRuleset(instance) {
+      var prototypeRuleset = _aureliaMetadata.metadata.get(_metadataKey.validationMetadataKey, instance);
+      if (prototypeRuleset) {
+        return prototypeRuleset;
+      } else {
+        return undefined;
+      }
+    };
+
+    ValidationRuleset.prototype.ensure = function ensure(property) {
+      this.currentProperty = property;
+      return this;
+    };
+
+    ValidationRuleset.prototype.length = function length(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.lengthRule(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.presence = function presence(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.presence(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.required = function required(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.presence(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.numericality = function numericality(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.numericality(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.date = function date(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.date(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.datetime = function datetime(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.datetime(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.email = function email(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.email(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.equality = function equality(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.equality(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.format = function format(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.format(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.inclusion = function inclusion(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.inclusion(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.exclusion = function exclusion(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.exclusion(configuration));
+      return this;
+    };
+
+    ValidationRuleset.prototype.url = function url(configuration) {
+      this.addRule(this.currentProperty, _validationRule.ValidationRule.url(configuration));
+      return this;
+    };
+
+    return ValidationRuleset;
+  }();
+});

--- a/dist/amd/validator-lite.js
+++ b/dist/amd/validator-lite.js
@@ -1,0 +1,96 @@
+define(['exports', './validation-ruleset', './validation-rule', './validation-engine'], function (exports, _validationRuleset, _validationRule, _validationEngine) {
+  'use strict';
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.ValidatorLite = undefined;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+    }
+
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
+    });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+  }
+
+  var ValidatorLite = exports.ValidatorLite = function (_ValidationRuleset) {
+    _inherits(ValidatorLite, _ValidationRuleset);
+
+    function ValidatorLite(targetObject) {
+      _classCallCheck(this, ValidatorLite);
+
+      var _this = _possibleConstructorReturn(this, _ValidationRuleset.call(this));
+
+      _this.targetObject = targetObject;
+      return _this;
+    }
+
+    ValidatorLite.prototype.addRule = function addRule(key, rule) {
+      _ValidationRuleset.prototype.addRule.call(this, key, rule);
+    };
+
+    ValidatorLite.prototype.importRuleset = function importRuleset(ruleset) {
+      for (var _iterator = ruleset, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+        var _ref;
+
+        if (_isArray) {
+          if (_i >= _iterator.length) break;
+          _ref = _iterator[_i++];
+        } else {
+          _i = _iterator.next();
+          if (_i.done) break;
+          _ref = _i.value;
+        }
+
+        var rule = _ref;
+
+        this.addRule(rule.key, new _validationRule.ValidationRule(rule.rule.name, JSON.parse(JSON.stringify(rule.rule.config))));
+      }
+    };
+
+    ValidatorLite.prototype.getProperties = function getProperties() {
+      console.error('Not yet implemented');
+    };
+
+    ValidatorLite.for = function _for(object) {
+      return new ValidatorLite(object);
+    };
+
+    ValidatorLite.prototype.validate = function validate(property) {
+      if (property) {
+        return _ValidationRuleset.prototype.validate.call(this, this.targetObject, property, true);
+      } else {
+        return _ValidationRuleset.prototype.validate.call(this, this.targetObject, null, true);
+      }
+    };
+
+    ValidatorLite.prototype.getValidationReporter = function getValidationReporter() {
+      return _validationEngine.ValidationEngine.getOrCreateValidationReporter(this.targetObject);
+    };
+
+    return ValidatorLite;
+  }(_validationRuleset.ValidationRuleset);
+});

--- a/dist/amd/validator.js
+++ b/dist/amd/validator.js
@@ -1,4 +1,4 @@
-define(['exports', './metadata-key', './validation-config', './validation-engine', './validation-rule', 'aurelia-metadata'], function (exports, _metadataKey, _validationConfig, _validationEngine, _validationRule, _aureliaMetadata) {
+define(['exports', 'aurelia-metadata', './validation-ruleset', './validation-engine', './metadata-key', './property-observer'], function (exports, _aureliaMetadata, _validationRuleset, _validationEngine, _metadataKey, _propertyObserver) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
@@ -12,94 +12,59 @@ define(['exports', './metadata-key', './validation-config', './validation-engine
     }
   }
 
-  var Validator = exports.Validator = function () {
-    function Validator(object) {
-      _classCallCheck(this, Validator);
-
-      this.object = object;
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
     }
 
-    Validator.prototype.validate = function validate(prop) {
-      var config = _aureliaMetadata.metadata.getOrCreateOwn(_metadataKey.validationMetadataKey, _validationConfig.ValidationConfig, this.object);
-      var reporter = _validationEngine.ValidationEngine.getValidationReporter(this.object);
-      if (prop) {
-        config.validate(this.object, reporter, prop);
-      } else {
-        config.validate(this.object, reporter);
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
       }
+    });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+  }
+
+  var Validator = exports.Validator = function (_ValidatorLite) {
+    _inherits(Validator, _ValidatorLite);
+
+    function Validator(targetObject) {
+      _classCallCheck(this, Validator);
+
+      var _this = _possibleConstructorReturn(this, _ValidatorLite.call(this, targetObject));
+
+      var prototypeRuleset = _validationRuleset.ValidationRuleset.getDecoratorsRuleset(targetObject);
+      if (prototypeRuleset) {
+        _this.importRuleset(prototypeRuleset);
+      }
+      return _this;
+    }
+
+    Validator.prototype.addRule = function addRule(key, rule) {
+      _ValidatorLite.prototype.addRule.call(this, key, rule);
+      (0, _propertyObserver.observeProperty)(this.targetObject, key, undefined, null, rule, this);
     };
 
-    Validator.prototype.getProperties = function getProperties() {
-      console.error('Not yet implemented');
+    Validator.for = function _for(object) {
+      return new Validator(object);
     };
 
-    Validator.prototype.ensure = function ensure(prop) {
-      var config = _aureliaMetadata.metadata.getOrCreateOwn(_metadataKey.validationMetadataKey, _validationConfig.ValidationConfig, this.object);
-      this.config = config;
-      this.currentProperty = prop;
-      return this;
-    };
-
-    Validator.prototype.length = function length(configuration) {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.lengthRule(configuration));
-      return this;
-    };
-
-    Validator.prototype.presence = function presence() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.presence());
-      return this;
-    };
-
-    Validator.prototype.required = function required() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.presence());
-      return this;
-    };
-
-    Validator.prototype.numericality = function numericality() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.numericality());
-      return this;
-    };
-
-    Validator.prototype.date = function date() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.date());
-      return this;
-    };
-
-    Validator.prototype.datetime = function datetime() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.datetime());
-      return this;
-    };
-
-    Validator.prototype.email = function email() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.email());
-      return this;
-    };
-
-    Validator.prototype.equality = function equality(configuration) {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.equality(configuration));
-      return this;
-    };
-
-    Validator.prototype.format = function format(configuration) {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.format(configuration));
-      return this;
-    };
-
-    Validator.prototype.inclusion = function inclusion(configuration) {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.inclusion(configuration));
-      return this;
-    };
-
-    Validator.prototype.exclusion = function exclusion(configuration) {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.exclusion(configuration));
-      return this;
-    };
-
-    Validator.prototype.url = function url() {
-      this.config.addRule(this.currentProperty, _validationRule.ValidationRule.url());
-      return this;
+    Validator.prototype.validate = function validate(property) {
+      _validationEngine.ValidationEngine.ensureValidationReporter(this.targetObject);
+      return _ValidatorLite.prototype.validate.call(this, property);
     };
 
     return Validator;
-  }();
+  }(ValidatorLite);
 });

--- a/dist/commonjs/decorators.js
+++ b/dist/commonjs/decorators.js
@@ -15,6 +15,7 @@ exports.inclusion = inclusion;
 exports.format = format;
 exports.url = url;
 exports.numericality = numericality;
+exports.custom = custom;
 
 var _validationRule = require('./validation-rule');
 
@@ -66,4 +67,12 @@ function url(targetOrConfig, key, descriptor) {
 
 function numericality(targetOrConfig, key, descriptor) {
   return (0, _baseDecorator.base)(targetOrConfig, key, descriptor, _validationRule.ValidationRule.numericality);
+}
+
+function custom(name, targetOrConfig, key, descriptor) {
+  targetOrConfig = {
+    name: name,
+    config: targetOrConfig === undefined ? true : targetOrConfig
+  };
+  return (0, _baseDecorator.base)(targetOrConfig, key, descriptor, _validationRule.ValidationRule.custom);
 }

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.ValidationRenderer = exports.ValidationReporter = exports.Validator = exports.ValidationEngine = exports.numericality = exports.url = exports.format = exports.inclusion = exports.exclusion = exports.equality = exports.email = exports.datetime = exports.date = exports.required = exports.length = undefined;
+exports.ValidationRenderer = exports.ValidationReporter = exports.ValidationRuleset = exports.ValidatorLite = exports.Validator = exports.ValidationEngine = exports.custom = exports.numericality = exports.url = exports.format = exports.inclusion = exports.exclusion = exports.equality = exports.email = exports.datetime = exports.date = exports.required = exports.length = undefined;
 
 var _decorators = require('./decorators');
 
@@ -73,6 +73,12 @@ Object.defineProperty(exports, 'numericality', {
     return _decorators.numericality;
   }
 });
+Object.defineProperty(exports, 'custom', {
+  enumerable: true,
+  get: function get() {
+    return _decorators.custom;
+  }
+});
 
 var _validationEngine = require('./validation-engine');
 
@@ -89,6 +95,24 @@ Object.defineProperty(exports, 'Validator', {
   enumerable: true,
   get: function get() {
     return _validator.Validator;
+  }
+});
+
+var _validatorLite = require('./validator-lite');
+
+Object.defineProperty(exports, 'ValidatorLite', {
+  enumerable: true,
+  get: function get() {
+    return _validatorLite.ValidatorLite;
+  }
+});
+
+var _validationRuleset = require('./validation-ruleset');
+
+Object.defineProperty(exports, 'ValidationRuleset', {
+  enumerable: true,
+  get: function get() {
+    return _validationRuleset.ValidationRuleset;
   }
 });
 
@@ -116,5 +140,6 @@ var _aureliaValidation = require('aurelia-validation');
 function configure(config) {
   config.container.registerHandler(_aureliaValidation.Validator, _validator.Validator);
   config.container.registerHandler(_aureliaValidation.ValidationReporter, _validationReporter.ValidationReporter);
-  config.globalResources('./validate-binding-behavior');
+  config.globalResources('./validation-rendering-binding-behavior');
+  config.globalResources('./live-validation-rendering-binding-behavior');
 }

--- a/dist/commonjs/live-validation-rendering-binding-behavior.js
+++ b/dist/commonjs/live-validation-rendering-binding-behavior.js
@@ -1,0 +1,75 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.LiveValidationRenderingBindingBehavior = undefined;
+
+var _dec, _class;
+
+var _validationRenderer = require('./validation-renderer');
+
+var _aureliaDependencyInjection = require('aurelia-dependency-injection');
+
+var _validationEngine = require('./validation-engine');
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var LiveValidationRenderingBindingBehavior = exports.LiveValidationRenderingBindingBehavior = (_dec = (0, _aureliaDependencyInjection.inject)(_validationRenderer.ValidationRenderer), _dec(_class = function () {
+  function LiveValidationRenderingBindingBehavior(renderer) {
+    _classCallCheck(this, LiveValidationRenderingBindingBehavior);
+
+    this.renderer = renderer;
+    this.liveBinding = true;
+  }
+
+  LiveValidationRenderingBindingBehavior.prototype.bind = function bind(binding, source) {
+    var _this = this;
+
+    var targetProperty = void 0;
+    var target = void 0;
+    var reporter = void 0;
+
+    binding.target._dirty = false;
+    binding.target.addEventListener('focus', function (event) {
+      binding.target._dirty = true;
+    });
+    targetProperty = this.getTargetProperty(binding);
+    target = this.getTargetObject(binding);
+    reporter = _validationEngine.ValidationEngine.getOrCreateValidationReporter(target);
+    reporter.subscribe(function (errors, pushRendering) {
+      var relevantErrors = errors.filter(function (error) {
+        return error.propertyName === targetProperty;
+      });
+
+      if (_this.liveBinding && binding.target._dirty || pushRendering) _this.renderer.renderErrors(binding.target, relevantErrors);
+    });
+  };
+
+  LiveValidationRenderingBindingBehavior.prototype.unbind = function unbind(binding, source) {};
+
+  LiveValidationRenderingBindingBehavior.prototype.getTargetProperty = function getTargetProperty(binding) {
+    var targetProperty = void 0;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+      targetProperty = binding.sourceExpression.expression.name;
+    }
+    return targetProperty;
+  };
+
+  LiveValidationRenderingBindingBehavior.prototype.getTargetObject = function getTargetObject(binding) {
+    var targetObject = void 0;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+      targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+    } else {
+      targetObject = binding.source.bindingContext;
+    }
+    return targetObject;
+  };
+
+  LiveValidationRenderingBindingBehavior.prototype.getPropertyContext = function getPropertyContext(source, targetProperty) {
+    var target = getContextFor(source, targetProperty);
+    return target;
+  };
+
+  return LiveValidationRenderingBindingBehavior;
+}()) || _class);

--- a/dist/commonjs/validation-engine.js
+++ b/dist/commonjs/validation-engine.js
@@ -15,7 +15,16 @@ var ValidationEngine = exports.ValidationEngine = function () {
   }
 
   ValidationEngine.getValidationReporter = function getValidationReporter(instance) {
-    return instance.__validationReporter__ || (instance.__validationReporter__ = new _validationReporter.ValidationReporter());
+    return instance.__validationReporter__;
+  };
+
+  ValidationEngine.ensureValidationReporter = function ensureValidationReporter(instance) {
+    if (!instance.__validationReporter__) instance.__validationReporter__ = new _validationReporter.ValidationReporter();
+  };
+
+  ValidationEngine.getOrCreateValidationReporter = function getOrCreateValidationReporter(instance) {
+    ValidationEngine.ensureValidationReporter(instance);
+    return ValidationEngine.getValidationReporter(instance);
   };
 
   return ValidationEngine;

--- a/dist/commonjs/validation-renderer.js
+++ b/dist/commonjs/validation-renderer.js
@@ -16,18 +16,21 @@ var ValidationRenderer = exports.ValidationRenderer = function () {
 
   ValidationRenderer.prototype.renderErrors = function renderErrors(node, relevantErrors) {
     if (relevantErrors.length) {
+      this.unrenderErrors(node);
       node.parentElement.classList.add('has-error');
       relevantErrors.forEach(function (error) {
         if (node.parentElement.textContent.indexOf(error.message) === -1) {
           var errorMessageHelper = _aureliaPal.DOM.createElement('span');
           var errorMessageNode = _aureliaPal.DOM.createTextNode(error.message);
           errorMessageHelper.appendChild(errorMessageNode);
-          errorMessageHelper.classList.add('help-block');
+          errorMessageHelper.classList.add('help-block', 'au-validation');
           node.parentElement.appendChild(errorMessageHelper);
         }
       });
     } else {
-      this.unrenderErrors(node);
+      if (node.parentElement.classList.contains('has-error')) {
+        this.unrenderErrors(node);
+      }
     }
   };
 
@@ -37,7 +40,7 @@ var ValidationRenderer = exports.ValidationRenderer = function () {
     var children = node.parentElement.children;
     for (var i = 0; i < children.length; i++) {
       var child = children[i];
-      if (child.classList.contains('help-block')) {
+      if (child.classList.contains('help-block') && child.classList.contains('au-validation')) {
         deleteThese.push(child);
       }
     }

--- a/dist/commonjs/validation-rendering-binding-behavior.js
+++ b/dist/commonjs/validation-rendering-binding-behavior.js
@@ -1,0 +1,73 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.ValidationRenderingBindingBehavior = undefined;
+
+var _dec, _class;
+
+var _validationRenderer = require('./validation-renderer');
+
+var _aureliaDependencyInjection = require('aurelia-dependency-injection');
+
+var _validationEngine = require('./validation-engine');
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var ValidationRenderingBindingBehavior = exports.ValidationRenderingBindingBehavior = (_dec = (0, _aureliaDependencyInjection.inject)(_validationRenderer.ValidationRenderer), _dec(_class = function () {
+  function ValidationRenderingBindingBehavior(renderer) {
+    _classCallCheck(this, ValidationRenderingBindingBehavior);
+
+    this.renderer = renderer;
+    this.liveBinding = false;
+  }
+
+  ValidationRenderingBindingBehavior.prototype.bind = function bind(binding, source) {
+    var _this = this;
+
+    var targetProperty = void 0;
+    var target = void 0;
+    var reporter = void 0;
+    source._dirty = false;
+    binding.target.addEventListener('focus', function (event) {
+      source._dirty = true;
+    });
+    targetProperty = this.getTargetProperty(binding);
+    target = this.getTargetObject(binding);
+    reporter = _validationEngine.ValidationEngine.getOrCreateValidationReporter(target);
+    reporter.subscribe(function (errors, pushRendering) {
+      var relevantErrors = errors.filter(function (error) {
+        return error.propertyName === targetProperty;
+      });
+      if (_this.liveBinding && source._dirty || pushRendering) _this.renderer.renderErrors(binding.target, relevantErrors);
+    });
+  };
+
+  ValidationRenderingBindingBehavior.prototype.unbind = function unbind(binding, source) {};
+
+  ValidationRenderingBindingBehavior.prototype.getTargetProperty = function getTargetProperty(binding) {
+    var targetProperty = void 0;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+      targetProperty = binding.sourceExpression.expression.name;
+    }
+    return targetProperty;
+  };
+
+  ValidationRenderingBindingBehavior.prototype.getTargetObject = function getTargetObject(binding) {
+    var targetObject = void 0;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+      targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+    } else {
+      targetObject = binding.source.bindingContext;
+    }
+    return targetObject;
+  };
+
+  ValidationRenderingBindingBehavior.prototype.getPropertyContext = function getPropertyContext(source, targetProperty) {
+    var target = getContextFor(source, targetProperty);
+    return target;
+  };
+
+  return ValidationRenderingBindingBehavior;
+}()) || _class);

--- a/dist/commonjs/validation-reporter.js
+++ b/dist/commonjs/validation-reporter.js
@@ -42,7 +42,7 @@ var ValidationReporter = exports.ValidationReporter = function () {
     return observer;
   };
 
-  ValidationReporter.prototype.publish = function publish(errors) {
+  ValidationReporter.prototype.publish = function publish(errors, pushRendering) {
     for (var _iterator = Object.keys(this.__callbacks__), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
       var _ref;
 
@@ -58,7 +58,7 @@ var ValidationReporter = exports.ValidationReporter = function () {
       var key = _ref;
 
       var observer = this.__callbacks__[key];
-      observer.callback(errors);
+      observer.callback(errors, pushRendering);
     }
   };
 

--- a/dist/commonjs/validation-rule.js
+++ b/dist/commonjs/validation-rule.js
@@ -68,6 +68,14 @@ var ValidationRule = exports.ValidationRule = function () {
   };
 
   ValidationRule.format = function format(config) {
+    if (config instanceof RegExp) {
+      var pattern = config.toString();
+      pattern = pattern.substr(1, pattern.length - 2);
+      config = {
+        pattern: pattern
+      };
+    }
+
     return new ValidationRule('format', config);
   };
 
@@ -95,6 +103,17 @@ var ValidationRule = exports.ValidationRule = function () {
     var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
     return new ValidationRule('url', config);
+  };
+
+  ValidationRule.custom = function custom() {
+    var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+    var name = arguments[1];
+
+    if (Reflect.has(config, "name")) {
+      return new ValidationRule(config.name, config.config);
+    } else {
+      return new ValidationRule(name, config);
+    }
   };
 
   return ValidationRule;

--- a/dist/commonjs/validation-ruleset.js
+++ b/dist/commonjs/validation-ruleset.js
@@ -1,0 +1,129 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.ValidationRuleset = undefined;
+
+var _validationRule = require('./validation-rule');
+
+var _validationEngine = require('./validation-engine');
+
+var _aureliaMetadata = require('aurelia-metadata');
+
+var _metadataKey = require('./metadata-key');
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var ValidationRuleset = exports.ValidationRuleset = function () {
+  function ValidationRuleset() {
+    _classCallCheck(this, ValidationRuleset);
+
+    this.__validationRules__ = [];
+  }
+
+  ValidationRuleset.for = function _for(object) {
+    return new Validator(object);
+  };
+
+  ValidationRuleset.prototype.addRule = function addRule(key, rule) {
+    this.__validationRules__.push({ key: key, rule: rule });
+  };
+
+  ValidationRuleset.prototype.validate = function validate(instance, property, _pushRendering) {
+    var errors = [];
+
+    var reporter = _validationEngine.ValidationEngine.getValidationReporter(instance);
+    this.__validationRules__.forEach(function (rule) {
+      if (!property || property === rule.key) {
+        var result = rule.rule.validate(instance, rule.key);
+        if (result) {
+          errors.push(result);
+        }
+      }
+    });
+
+    if (reporter) reporter.publish(errors, _pushRendering);
+    return errors;
+  };
+
+  ValidationRuleset.prototype[Symbol.iterator] = function () {
+    return this.__validationRules__[Symbol.iterator]();
+  };
+
+  ValidationRuleset.getDecoratorsRuleset = function getDecoratorsRuleset(instance) {
+    var prototypeRuleset = _aureliaMetadata.metadata.get(_metadataKey.validationMetadataKey, instance);
+    if (prototypeRuleset) {
+      return prototypeRuleset;
+    } else {
+      return undefined;
+    }
+  };
+
+  ValidationRuleset.prototype.ensure = function ensure(property) {
+    this.currentProperty = property;
+    return this;
+  };
+
+  ValidationRuleset.prototype.length = function length(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.lengthRule(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.presence = function presence(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.presence(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.required = function required(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.presence(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.numericality = function numericality(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.numericality(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.date = function date(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.date(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.datetime = function datetime(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.datetime(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.email = function email(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.email(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.equality = function equality(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.equality(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.format = function format(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.format(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.inclusion = function inclusion(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.inclusion(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.exclusion = function exclusion(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.exclusion(configuration));
+    return this;
+  };
+
+  ValidationRuleset.prototype.url = function url(configuration) {
+    this.addRule(this.currentProperty, _validationRule.ValidationRule.url(configuration));
+    return this;
+  };
+
+  return ValidationRuleset;
+}();

--- a/dist/commonjs/validator-lite.js
+++ b/dist/commonjs/validator-lite.js
@@ -1,0 +1,76 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.ValidatorLite = undefined;
+
+var _validationRuleset = require('./validation-ruleset');
+
+var _validationRule = require('./validation-rule');
+
+var _validationEngine = require('./validation-engine');
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var ValidatorLite = exports.ValidatorLite = function (_ValidationRuleset) {
+  _inherits(ValidatorLite, _ValidationRuleset);
+
+  function ValidatorLite(targetObject) {
+    _classCallCheck(this, ValidatorLite);
+
+    var _this = _possibleConstructorReturn(this, _ValidationRuleset.call(this));
+
+    _this.targetObject = targetObject;
+    return _this;
+  }
+
+  ValidatorLite.prototype.addRule = function addRule(key, rule) {
+    _ValidationRuleset.prototype.addRule.call(this, key, rule);
+  };
+
+  ValidatorLite.prototype.importRuleset = function importRuleset(ruleset) {
+    for (var _iterator = ruleset, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+      var _ref;
+
+      if (_isArray) {
+        if (_i >= _iterator.length) break;
+        _ref = _iterator[_i++];
+      } else {
+        _i = _iterator.next();
+        if (_i.done) break;
+        _ref = _i.value;
+      }
+
+      var rule = _ref;
+
+      this.addRule(rule.key, new _validationRule.ValidationRule(rule.rule.name, JSON.parse(JSON.stringify(rule.rule.config))));
+    }
+  };
+
+  ValidatorLite.prototype.getProperties = function getProperties() {
+    console.error('Not yet implemented');
+  };
+
+  ValidatorLite.for = function _for(object) {
+    return new ValidatorLite(object);
+  };
+
+  ValidatorLite.prototype.validate = function validate(property) {
+    if (property) {
+      return _ValidationRuleset.prototype.validate.call(this, this.targetObject, property, true);
+    } else {
+      return _ValidationRuleset.prototype.validate.call(this, this.targetObject, null, true);
+    }
+  };
+
+  ValidatorLite.prototype.getValidationReporter = function getValidationReporter() {
+    return _validationEngine.ValidationEngine.getOrCreateValidationReporter(this.targetObject);
+  };
+
+  return ValidatorLite;
+}(_validationRuleset.ValidationRuleset);

--- a/dist/commonjs/validator.js
+++ b/dist/commonjs/validator.js
@@ -5,105 +5,50 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Validator = undefined;
 
-var _metadataKey = require('./metadata-key');
+var _aureliaMetadata = require('aurelia-metadata');
 
-var _validationConfig = require('./validation-config');
+var _validationRuleset = require('./validation-ruleset');
 
 var _validationEngine = require('./validation-engine');
 
-var _validationRule = require('./validation-rule');
+var _metadataKey = require('./metadata-key');
 
-var _aureliaMetadata = require('aurelia-metadata');
+var _propertyObserver = require('./property-observer');
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var Validator = exports.Validator = function () {
-  function Validator(object) {
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Validator = exports.Validator = function (_ValidatorLite) {
+  _inherits(Validator, _ValidatorLite);
+
+  function Validator(targetObject) {
     _classCallCheck(this, Validator);
 
-    this.object = object;
+    var _this = _possibleConstructorReturn(this, _ValidatorLite.call(this, targetObject));
+
+    var prototypeRuleset = _validationRuleset.ValidationRuleset.getDecoratorsRuleset(targetObject);
+    if (prototypeRuleset) {
+      _this.importRuleset(prototypeRuleset);
+    }
+    return _this;
   }
 
-  Validator.prototype.validate = function validate(prop) {
-    var config = _aureliaMetadata.metadata.getOrCreateOwn(_metadataKey.validationMetadataKey, _validationConfig.ValidationConfig, this.object);
-    var reporter = _validationEngine.ValidationEngine.getValidationReporter(this.object);
-    if (prop) {
-      config.validate(this.object, reporter, prop);
-    } else {
-      config.validate(this.object, reporter);
-    }
+  Validator.prototype.addRule = function addRule(key, rule) {
+    _ValidatorLite.prototype.addRule.call(this, key, rule);
+    (0, _propertyObserver.observeProperty)(this.targetObject, key, undefined, null, rule, this);
   };
 
-  Validator.prototype.getProperties = function getProperties() {
-    console.error('Not yet implemented');
+  Validator.for = function _for(object) {
+    return new Validator(object);
   };
 
-  Validator.prototype.ensure = function ensure(prop) {
-    var config = _aureliaMetadata.metadata.getOrCreateOwn(_metadataKey.validationMetadataKey, _validationConfig.ValidationConfig, this.object);
-    this.config = config;
-    this.currentProperty = prop;
-    return this;
-  };
-
-  Validator.prototype.length = function length(configuration) {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.lengthRule(configuration));
-    return this;
-  };
-
-  Validator.prototype.presence = function presence() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.presence());
-    return this;
-  };
-
-  Validator.prototype.required = function required() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.presence());
-    return this;
-  };
-
-  Validator.prototype.numericality = function numericality() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.numericality());
-    return this;
-  };
-
-  Validator.prototype.date = function date() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.date());
-    return this;
-  };
-
-  Validator.prototype.datetime = function datetime() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.datetime());
-    return this;
-  };
-
-  Validator.prototype.email = function email() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.email());
-    return this;
-  };
-
-  Validator.prototype.equality = function equality(configuration) {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.equality(configuration));
-    return this;
-  };
-
-  Validator.prototype.format = function format(configuration) {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.format(configuration));
-    return this;
-  };
-
-  Validator.prototype.inclusion = function inclusion(configuration) {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.inclusion(configuration));
-    return this;
-  };
-
-  Validator.prototype.exclusion = function exclusion(configuration) {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.exclusion(configuration));
-    return this;
-  };
-
-  Validator.prototype.url = function url() {
-    this.config.addRule(this.currentProperty, _validationRule.ValidationRule.url());
-    return this;
+  Validator.prototype.validate = function validate(property) {
+    _validationEngine.ValidationEngine.ensureValidationReporter(this.targetObject);
+    return _ValidatorLite.prototype.validate.call(this, property);
   };
 
   return Validator;
-}();
+}(ValidatorLite);

--- a/dist/es2015/decorators.js
+++ b/dist/es2015/decorators.js
@@ -48,3 +48,11 @@ export function url(targetOrConfig, key, descriptor) {
 export function numericality(targetOrConfig, key, descriptor) {
   return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
 }
+
+export function custom(name, targetOrConfig, key, descriptor) {
+  targetOrConfig = {
+    name: name,
+    config: targetOrConfig === undefined ? true : targetOrConfig
+  };
+  return base(targetOrConfig, key, descriptor, ValidationRule.custom);
+}

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -1,8 +1,10 @@
-export { length, required, date, datetime, email, equality, exclusion, inclusion, format, url, numericality } from './decorators';
+export { length, required, date, datetime, email, equality, exclusion, inclusion, format, url, numericality, custom } from './decorators';
 export { ValidationEngine } from './validation-engine';
 import { Validator } from 'aurelia-validation';
 import { Validator as ValidateJSValidator } from './validator';
 export { Validator } from './validator';
+export { ValidatorLite } from './validator-lite';
+export { ValidationRuleset } from './validation-ruleset';
 import { ValidationReporter } from 'aurelia-validation';
 import { ValidationReporter as ValidateJSReporter } from './validation-reporter';
 export { ValidationReporter } from './validation-reporter';
@@ -11,5 +13,6 @@ export { ValidationRenderer } from './validation-renderer';
 export function configure(config) {
   config.container.registerHandler(Validator, ValidateJSValidator);
   config.container.registerHandler(ValidationReporter, ValidateJSReporter);
-  config.globalResources('./validate-binding-behavior');
+  config.globalResources('./validation-rendering-binding-behavior');
+  config.globalResources('./live-validation-rendering-binding-behavior');
 }

--- a/dist/es2015/live-validation-rendering-binding-behavior.js
+++ b/dist/es2015/live-validation-rendering-binding-behavior.js
@@ -1,0 +1,56 @@
+var _dec, _class;
+
+import { ValidationRenderer } from './validation-renderer';
+import { inject } from 'aurelia-dependency-injection';
+import { ValidationEngine } from './validation-engine';
+
+export let LiveValidationRenderingBindingBehavior = (_dec = inject(ValidationRenderer), _dec(_class = class LiveValidationRenderingBindingBehavior {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.liveBinding = true;
+  }
+
+  bind(binding, source) {
+    let targetProperty;
+    let target;
+    let reporter;
+
+    binding.target._dirty = false;
+    binding.target.addEventListener('focus', event => {
+      binding.target._dirty = true;
+    });
+    targetProperty = this.getTargetProperty(binding);
+    target = this.getTargetObject(binding);
+    reporter = ValidationEngine.getOrCreateValidationReporter(target);
+    reporter.subscribe((errors, pushRendering) => {
+      let relevantErrors = errors.filter(error => {
+        return error.propertyName === targetProperty;
+      });
+
+      if (this.liveBinding && binding.target._dirty || pushRendering) this.renderer.renderErrors(binding.target, relevantErrors);
+    });
+  }
+
+  unbind(binding, source) {}
+
+  getTargetProperty(binding) {
+    let targetProperty;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+      targetProperty = binding.sourceExpression.expression.name;
+    }
+    return targetProperty;
+  }
+  getTargetObject(binding) {
+    let targetObject;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+      targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+    } else {
+      targetObject = binding.source.bindingContext;
+    }
+    return targetObject;
+  }
+  getPropertyContext(source, targetProperty) {
+    let target = getContextFor(source, targetProperty);
+    return target;
+  }
+}) || _class);

--- a/dist/es2015/validation-engine.js
+++ b/dist/es2015/validation-engine.js
@@ -2,6 +2,15 @@ import { ValidationReporter } from './validation-reporter';
 
 export let ValidationEngine = class ValidationEngine {
   static getValidationReporter(instance) {
-    return instance.__validationReporter__ || (instance.__validationReporter__ = new ValidationReporter());
+    return instance.__validationReporter__;
+  }
+
+  static ensureValidationReporter(instance) {
+    if (!instance.__validationReporter__) instance.__validationReporter__ = new ValidationReporter();
+  }
+
+  static getOrCreateValidationReporter(instance) {
+    ValidationEngine.ensureValidationReporter(instance);
+    return ValidationEngine.getValidationReporter(instance);
   }
 };

--- a/dist/es2015/validation-renderer.js
+++ b/dist/es2015/validation-renderer.js
@@ -3,18 +3,21 @@ import { DOM } from 'aurelia-pal';
 export let ValidationRenderer = class ValidationRenderer {
   renderErrors(node, relevantErrors) {
     if (relevantErrors.length) {
+      this.unrenderErrors(node);
       node.parentElement.classList.add('has-error');
       relevantErrors.forEach(error => {
         if (node.parentElement.textContent.indexOf(error.message) === -1) {
           let errorMessageHelper = DOM.createElement('span');
           let errorMessageNode = DOM.createTextNode(error.message);
           errorMessageHelper.appendChild(errorMessageNode);
-          errorMessageHelper.classList.add('help-block');
+          errorMessageHelper.classList.add('help-block', 'au-validation');
           node.parentElement.appendChild(errorMessageHelper);
         }
       });
     } else {
-      this.unrenderErrors(node);
+      if (node.parentElement.classList.contains('has-error')) {
+        this.unrenderErrors(node);
+      }
     }
   }
   unrenderErrors(node) {
@@ -23,7 +26,7 @@ export let ValidationRenderer = class ValidationRenderer {
     let children = node.parentElement.children;
     for (let i = 0; i < children.length; i++) {
       let child = children[i];
-      if (child.classList.contains('help-block')) {
+      if (child.classList.contains('help-block') && child.classList.contains('au-validation')) {
         deleteThese.push(child);
       }
     }

--- a/dist/es2015/validation-rendering-binding-behavior.js
+++ b/dist/es2015/validation-rendering-binding-behavior.js
@@ -1,0 +1,54 @@
+var _dec, _class;
+
+import { ValidationRenderer } from './validation-renderer';
+import { inject } from 'aurelia-dependency-injection';
+import { ValidationEngine } from './validation-engine';
+
+export let ValidationRenderingBindingBehavior = (_dec = inject(ValidationRenderer), _dec(_class = class ValidationRenderingBindingBehavior {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.liveBinding = false;
+  }
+
+  bind(binding, source) {
+    let targetProperty;
+    let target;
+    let reporter;
+    source._dirty = false;
+    binding.target.addEventListener('focus', event => {
+      source._dirty = true;
+    });
+    targetProperty = this.getTargetProperty(binding);
+    target = this.getTargetObject(binding);
+    reporter = ValidationEngine.getOrCreateValidationReporter(target);
+    reporter.subscribe((errors, pushRendering) => {
+      let relevantErrors = errors.filter(error => {
+        return error.propertyName === targetProperty;
+      });
+      if (this.liveBinding && source._dirty || pushRendering) this.renderer.renderErrors(binding.target, relevantErrors);
+    });
+  }
+
+  unbind(binding, source) {}
+
+  getTargetProperty(binding) {
+    let targetProperty;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+      targetProperty = binding.sourceExpression.expression.name;
+    }
+    return targetProperty;
+  }
+  getTargetObject(binding) {
+    let targetObject;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+      targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+    } else {
+      targetObject = binding.source.bindingContext;
+    }
+    return targetObject;
+  }
+  getPropertyContext(source, targetProperty) {
+    let target = getContextFor(source, targetProperty);
+    return target;
+  }
+}) || _class);

--- a/dist/es2015/validation-reporter.js
+++ b/dist/es2015/validation-reporter.js
@@ -26,10 +26,10 @@ export let ValidationReporter = class ValidationReporter {
     this.__callbacks__[observer.id] = observer;
     return observer;
   }
-  publish(errors) {
+  publish(errors, pushRendering) {
     for (let key of Object.keys(this.__callbacks__)) {
       let observer = this.__callbacks__[key];
-      observer.callback(errors);
+      observer.callback(errors, pushRendering);
     }
   }
   destroyObserver(observer) {

--- a/dist/es2015/validation-rule.js
+++ b/dist/es2015/validation-rule.js
@@ -35,7 +35,16 @@ export let ValidationRule = class ValidationRule {
   static exclusion(config) {
     return new ValidationRule('exclusion', config);
   }
+
   static format(config) {
+    if (config instanceof RegExp) {
+      let pattern = config.toString();
+      pattern = pattern.substr(1, pattern.length - 2);
+      config = {
+        pattern: pattern
+      };
+    }
+
     return new ValidationRule('format', config);
   }
   static inclusion(config) {
@@ -52,6 +61,14 @@ export let ValidationRule = class ValidationRule {
   }
   static url(config = true) {
     return new ValidationRule('url', config);
+  }
+
+  static custom(config = true, name) {
+    if (Reflect.has(config, "name")) {
+      return new ValidationRule(config.name, config.config);
+    } else {
+      return new ValidationRule(name, config);
+    }
   }
 };
 

--- a/dist/es2015/validation-ruleset.js
+++ b/dist/es2015/validation-ruleset.js
@@ -1,0 +1,101 @@
+import { ValidationRule } from './validation-rule';
+import { ValidationEngine } from './validation-engine';
+import { metadata } from 'aurelia-metadata';
+import { validationMetadataKey } from './metadata-key';
+
+export let ValidationRuleset = class ValidationRuleset {
+  constructor() {
+    this.__validationRules__ = [];
+  }
+
+  static for(object) {
+    return new Validator(object);
+  }
+
+  addRule(key, rule) {
+    this.__validationRules__.push({ key: key, rule: rule });
+  }
+
+  validate(instance, property, _pushRendering) {
+    let errors = [];
+
+    let reporter = ValidationEngine.getValidationReporter(instance);
+    this.__validationRules__.forEach(rule => {
+      if (!property || property === rule.key) {
+        let result = rule.rule.validate(instance, rule.key);
+        if (result) {
+          errors.push(result);
+        }
+      }
+    });
+
+    if (reporter) reporter.publish(errors, _pushRendering);
+    return errors;
+  }
+
+  [Symbol.iterator]() {
+    return this.__validationRules__[Symbol.iterator]();
+  }
+
+  static getDecoratorsRuleset(instance) {
+    let prototypeRuleset = metadata.get(validationMetadataKey, instance);
+    if (prototypeRuleset) {
+      return prototypeRuleset;
+    } else {
+      return undefined;
+    }
+  }
+
+  ensure(property) {
+    this.currentProperty = property;
+    return this;
+  }
+  length(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.lengthRule(configuration));
+    return this;
+  }
+  presence(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.presence(configuration));
+    return this;
+  }
+  required(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.presence(configuration));
+    return this;
+  }
+  numericality(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.numericality(configuration));
+    return this;
+  }
+  date(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.date(configuration));
+    return this;
+  }
+  datetime(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.datetime(configuration));
+    return this;
+  }
+  email(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.email(configuration));
+    return this;
+  }
+  equality(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.equality(configuration));
+    return this;
+  }
+  format(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.format(configuration));
+    return this;
+  }
+  inclusion(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.inclusion(configuration));
+    return this;
+  }
+  exclusion(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.exclusion(configuration));
+    return this;
+  }
+  url(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.url(configuration));
+    return this;
+  }
+};

--- a/dist/es2015/validator-lite.js
+++ b/dist/es2015/validator-lite.js
@@ -1,0 +1,41 @@
+import { ValidationRuleset } from './validation-ruleset';
+import { ValidationRule } from './validation-rule';
+import { ValidationEngine } from './validation-engine';
+
+export let ValidatorLite = class ValidatorLite extends ValidationRuleset {
+
+  constructor(targetObject) {
+    super();
+    this.targetObject = targetObject;
+  }
+
+  addRule(key, rule) {
+    super.addRule(key, rule);
+  }
+
+  importRuleset(ruleset) {
+    for (var rule of ruleset) {
+      this.addRule(rule.key, new ValidationRule(rule.rule.name, JSON.parse(JSON.stringify(rule.rule.config))));
+    }
+  }
+
+  getProperties() {
+    console.error('Not yet implemented');
+  }
+
+  static for(object) {
+    return new ValidatorLite(object);
+  }
+
+  validate(property) {
+    if (property) {
+      return super.validate(this.targetObject, property, true);
+    } else {
+      return super.validate(this.targetObject, null, true);
+    }
+  }
+
+  getValidationReporter() {
+    return ValidationEngine.getOrCreateValidationReporter(this.targetObject);
+  }
+};

--- a/dist/es2015/validator.js
+++ b/dist/es2015/validator.js
@@ -1,77 +1,29 @@
-import { validationMetadataKey } from './metadata-key';
-import { ValidationConfig } from './validation-config';
-import { ValidationEngine } from './validation-engine';
-import { ValidationRule } from './validation-rule';
 import { metadata } from 'aurelia-metadata';
+import { ValidationRuleset } from './validation-ruleset';
+import { ValidationEngine } from './validation-engine';
+import { validationMetadataKey } from './metadata-key';
+import { observeProperty } from './property-observer';
 
-export let Validator = class Validator {
-  constructor(object) {
-    this.object = object;
-  }
-  validate(prop) {
-    let config = metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, this.object);
-    let reporter = ValidationEngine.getValidationReporter(this.object);
-    if (prop) {
-      config.validate(this.object, reporter, prop);
-    } else {
-      config.validate(this.object, reporter);
+export let Validator = class Validator extends ValidatorLite {
+  constructor(targetObject) {
+    super(targetObject);
+    let prototypeRuleset = ValidationRuleset.getDecoratorsRuleset(targetObject);
+    if (prototypeRuleset) {
+      this.importRuleset(prototypeRuleset);
     }
   }
-  getProperties() {
-    console.error('Not yet implemented');
+
+  addRule(key, rule) {
+    super.addRule(key, rule);
+    observeProperty(this.targetObject, key, undefined, null, rule, this);
   }
-  ensure(prop) {
-    let config = metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, this.object);
-    this.config = config;
-    this.currentProperty = prop;
-    return this;
+
+  static for(object) {
+    return new Validator(object);
   }
-  length(configuration) {
-    this.config.addRule(this.currentProperty, ValidationRule.lengthRule(configuration));
-    return this;
-  }
-  presence() {
-    this.config.addRule(this.currentProperty, ValidationRule.presence());
-    return this;
-  }
-  required() {
-    this.config.addRule(this.currentProperty, ValidationRule.presence());
-    return this;
-  }
-  numericality() {
-    this.config.addRule(this.currentProperty, ValidationRule.numericality());
-    return this;
-  }
-  date() {
-    this.config.addRule(this.currentProperty, ValidationRule.date());
-    return this;
-  }
-  datetime() {
-    this.config.addRule(this.currentProperty, ValidationRule.datetime());
-    return this;
-  }
-  email() {
-    this.config.addRule(this.currentProperty, ValidationRule.email());
-    return this;
-  }
-  equality(configuration) {
-    this.config.addRule(this.currentProperty, ValidationRule.equality(configuration));
-    return this;
-  }
-  format(configuration) {
-    this.config.addRule(this.currentProperty, ValidationRule.format(configuration));
-    return this;
-  }
-  inclusion(configuration) {
-    this.config.addRule(this.currentProperty, ValidationRule.inclusion(configuration));
-    return this;
-  }
-  exclusion(configuration) {
-    this.config.addRule(this.currentProperty, ValidationRule.exclusion(configuration));
-    return this;
-  }
-  url() {
-    this.config.addRule(this.currentProperty, ValidationRule.url());
-    return this;
+
+  validate(property) {
+    ValidationEngine.ensureValidationReporter(this.targetObject);
+    return super.validate(property);
   }
 };

--- a/dist/system/decorators.js
+++ b/dist/system/decorators.js
@@ -80,6 +80,16 @@ System.register(['./validation-rule', './base-decorator'], function (_export, _c
       }
 
       _export('numericality', numericality);
+
+      function custom(name, targetOrConfig, key, descriptor) {
+        targetOrConfig = {
+          name: name,
+          config: targetOrConfig === undefined ? true : targetOrConfig
+        };
+        return base(targetOrConfig, key, descriptor, ValidationRule.custom);
+      }
+
+      _export('custom', custom);
     }
   };
 });

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-System.register(['./decorators', './validation-engine', 'aurelia-validation', './validator', './validation-reporter', './validation-renderer'], function (_export, _context) {
+System.register(['./decorators', './validation-engine', 'aurelia-validation', './validator', './validator-lite', './validation-ruleset', './validation-reporter', './validation-renderer'], function (_export, _context) {
   var Validator, ValidateJSValidator, ValidationReporter, ValidateJSReporter;
   return {
     setters: [function (_decorators) {
@@ -16,6 +16,7 @@ System.register(['./decorators', './validation-engine', 'aurelia-validation', '.
       _exportObj.format = _decorators.format;
       _exportObj.url = _decorators.url;
       _exportObj.numericality = _decorators.numericality;
+      _exportObj.custom = _decorators.custom;
 
       _export(_exportObj);
     }, function (_validationEngine) {
@@ -32,23 +33,34 @@ System.register(['./decorators', './validation-engine', 'aurelia-validation', '.
       _exportObj3.Validator = _validator.Validator;
 
       _export(_exportObj3);
-    }, function (_validationReporter) {
-      ValidateJSReporter = _validationReporter.ValidationReporter;
+    }, function (_validatorLite) {
       var _exportObj4 = {};
-      _exportObj4.ValidationReporter = _validationReporter.ValidationReporter;
+      _exportObj4.ValidatorLite = _validatorLite.ValidatorLite;
 
       _export(_exportObj4);
-    }, function (_validationRenderer) {
+    }, function (_validationRuleset) {
       var _exportObj5 = {};
-      _exportObj5.ValidationRenderer = _validationRenderer.ValidationRenderer;
+      _exportObj5.ValidationRuleset = _validationRuleset.ValidationRuleset;
 
       _export(_exportObj5);
+    }, function (_validationReporter) {
+      ValidateJSReporter = _validationReporter.ValidationReporter;
+      var _exportObj6 = {};
+      _exportObj6.ValidationReporter = _validationReporter.ValidationReporter;
+
+      _export(_exportObj6);
+    }, function (_validationRenderer) {
+      var _exportObj7 = {};
+      _exportObj7.ValidationRenderer = _validationRenderer.ValidationRenderer;
+
+      _export(_exportObj7);
     }],
     execute: function () {
       function configure(config) {
         config.container.registerHandler(Validator, ValidateJSValidator);
         config.container.registerHandler(ValidationReporter, ValidateJSReporter);
-        config.globalResources('./validate-binding-behavior');
+        config.globalResources('./validation-rendering-binding-behavior');
+        config.globalResources('./live-validation-rendering-binding-behavior');
       }
 
       _export('configure', configure);

--- a/dist/system/live-validation-rendering-binding-behavior.js
+++ b/dist/system/live-validation-rendering-binding-behavior.js
@@ -1,0 +1,83 @@
+'use strict';
+
+System.register(['./validation-renderer', 'aurelia-dependency-injection', './validation-engine'], function (_export, _context) {
+  var ValidationRenderer, inject, ValidationEngine, _dec, _class, LiveValidationRenderingBindingBehavior;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  return {
+    setters: [function (_validationRenderer) {
+      ValidationRenderer = _validationRenderer.ValidationRenderer;
+    }, function (_aureliaDependencyInjection) {
+      inject = _aureliaDependencyInjection.inject;
+    }, function (_validationEngine) {
+      ValidationEngine = _validationEngine.ValidationEngine;
+    }],
+    execute: function () {
+      _export('LiveValidationRenderingBindingBehavior', LiveValidationRenderingBindingBehavior = (_dec = inject(ValidationRenderer), _dec(_class = function () {
+        function LiveValidationRenderingBindingBehavior(renderer) {
+          _classCallCheck(this, LiveValidationRenderingBindingBehavior);
+
+          this.renderer = renderer;
+          this.liveBinding = true;
+        }
+
+        LiveValidationRenderingBindingBehavior.prototype.bind = function bind(binding, source) {
+          var _this = this;
+
+          var targetProperty = void 0;
+          var target = void 0;
+          var reporter = void 0;
+
+          binding.target._dirty = false;
+          binding.target.addEventListener('focus', function (event) {
+            binding.target._dirty = true;
+          });
+          targetProperty = this.getTargetProperty(binding);
+          target = this.getTargetObject(binding);
+          reporter = ValidationEngine.getOrCreateValidationReporter(target);
+          reporter.subscribe(function (errors, pushRendering) {
+            var relevantErrors = errors.filter(function (error) {
+              return error.propertyName === targetProperty;
+            });
+
+            if (_this.liveBinding && binding.target._dirty || pushRendering) _this.renderer.renderErrors(binding.target, relevantErrors);
+          });
+        };
+
+        LiveValidationRenderingBindingBehavior.prototype.unbind = function unbind(binding, source) {};
+
+        LiveValidationRenderingBindingBehavior.prototype.getTargetProperty = function getTargetProperty(binding) {
+          var targetProperty = void 0;
+          if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+            targetProperty = binding.sourceExpression.expression.name;
+          }
+          return targetProperty;
+        };
+
+        LiveValidationRenderingBindingBehavior.prototype.getTargetObject = function getTargetObject(binding) {
+          var targetObject = void 0;
+          if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+            targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+          } else {
+            targetObject = binding.source.bindingContext;
+          }
+          return targetObject;
+        };
+
+        LiveValidationRenderingBindingBehavior.prototype.getPropertyContext = function getPropertyContext(source, targetProperty) {
+          var target = getContextFor(source, targetProperty);
+          return target;
+        };
+
+        return LiveValidationRenderingBindingBehavior;
+      }()) || _class));
+
+      _export('LiveValidationRenderingBindingBehavior', LiveValidationRenderingBindingBehavior);
+    }
+  };
+});

--- a/dist/system/property-observer.js
+++ b/dist/system/property-observer.js
@@ -1,23 +1,39 @@
 'use strict';
 
-System.register(['aurelia-metadata', './validation-config', './validation-engine', './metadata-key'], function (_export, _context) {
-  var metadata, ValidationConfig, ValidationEngine, validationMetadataKey;
+System.register(['aurelia-metadata', './validation-ruleset', './validation-engine', './metadata-key', './validation-rule'], function (_export, _context) {
+  var metadata, ValidationRuleset, ValidationEngine, validationMetadataKey, ValidationRule;
   return {
     setters: [function (_aureliaMetadata) {
       metadata = _aureliaMetadata.metadata;
-    }, function (_validationConfig) {
-      ValidationConfig = _validationConfig.ValidationConfig;
+    }, function (_validationRuleset) {
+      ValidationRuleset = _validationRuleset.ValidationRuleset;
     }, function (_validationEngine) {
       ValidationEngine = _validationEngine.ValidationEngine;
     }, function (_metadataKey) {
       validationMetadataKey = _metadataKey.validationMetadataKey;
+    }, function (_validationRule) {
+      ValidationRule = _validationRule.ValidationRule;
     }],
     execute: function () {
-      function observeProperty(target, key, descriptor, targetOrConfig, rule) {
-        var config = metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, target);
-        config.addRule(key, rule(targetOrConfig));
+      function observeProperty(target, key, descriptor, targetOrConfig, rule, ruleset) {
+        if (rule instanceof ValidationRule) {
+          if (!Reflect.has(target, key)) {
+            return;
+          }
+        } else {
+          ruleset = metadata.getOrCreateOwn(validationMetadataKey, ValidationRuleset, target);
+          ruleset.addRule(key, rule(targetOrConfig));
+        }
 
         var innerPropertyName = '_' + key;
+
+        var existingDescriptor = Object.getOwnPropertyDescriptor(target, key);
+        var alreadyIntercepted = existingDescriptor !== undefined && existingDescriptor.get !== undefined && existingDescriptor.get.generatedBy == "au-validation";
+
+        var instanceValue = existingDescriptor !== undefined && existingDescriptor.value !== undefined ? existingDescriptor.value : undefined;
+        if (instanceValue === undefined) {
+          instanceValue = target[key];
+        }
 
         var babel = descriptor !== undefined;
 
@@ -36,17 +52,22 @@ System.register(['aurelia-metadata', './validation-config', './validation-engine
           return this[innerPropertyName];
         };
         descriptor.set = function (newValue) {
-          var reporter = ValidationEngine.getValidationReporter(this);
+          ValidationEngine.ensureValidationReporter(this);
 
           this[innerPropertyName] = newValue;
 
-          config.validate(this, reporter);
+          ValidationRuleset.prototype.validate.call(ruleset, this);
         };
 
         descriptor.get.dependencies = [innerPropertyName];
 
-        if (!babel) {
+        descriptor.get.generatedBy = "au-validation";
+
+        if (!babel && !alreadyIntercepted) {
           Reflect.defineProperty(target, key, descriptor);
+          if (instanceValue) {
+            target[innerPropertyName] = instanceValue;
+          }
         }
       }
 

--- a/dist/system/validation-engine.js
+++ b/dist/system/validation-engine.js
@@ -20,7 +20,16 @@ System.register(['./validation-reporter'], function (_export, _context) {
         }
 
         ValidationEngine.getValidationReporter = function getValidationReporter(instance) {
-          return instance.__validationReporter__ || (instance.__validationReporter__ = new ValidationReporter());
+          return instance.__validationReporter__;
+        };
+
+        ValidationEngine.ensureValidationReporter = function ensureValidationReporter(instance) {
+          if (!instance.__validationReporter__) instance.__validationReporter__ = new ValidationReporter();
+        };
+
+        ValidationEngine.getOrCreateValidationReporter = function getOrCreateValidationReporter(instance) {
+          ValidationEngine.ensureValidationReporter(instance);
+          return ValidationEngine.getValidationReporter(instance);
         };
 
         return ValidationEngine;

--- a/dist/system/validation-renderer.js
+++ b/dist/system/validation-renderer.js
@@ -21,18 +21,21 @@ System.register(['aurelia-pal'], function (_export, _context) {
 
         ValidationRenderer.prototype.renderErrors = function renderErrors(node, relevantErrors) {
           if (relevantErrors.length) {
+            this.unrenderErrors(node);
             node.parentElement.classList.add('has-error');
             relevantErrors.forEach(function (error) {
               if (node.parentElement.textContent.indexOf(error.message) === -1) {
                 var errorMessageHelper = DOM.createElement('span');
                 var errorMessageNode = DOM.createTextNode(error.message);
                 errorMessageHelper.appendChild(errorMessageNode);
-                errorMessageHelper.classList.add('help-block');
+                errorMessageHelper.classList.add('help-block', 'au-validation');
                 node.parentElement.appendChild(errorMessageHelper);
               }
             });
           } else {
-            this.unrenderErrors(node);
+            if (node.parentElement.classList.contains('has-error')) {
+              this.unrenderErrors(node);
+            }
           }
         };
 
@@ -42,7 +45,7 @@ System.register(['aurelia-pal'], function (_export, _context) {
           var children = node.parentElement.children;
           for (var i = 0; i < children.length; i++) {
             var child = children[i];
-            if (child.classList.contains('help-block')) {
+            if (child.classList.contains('help-block') && child.classList.contains('au-validation')) {
               deleteThese.push(child);
             }
           }

--- a/dist/system/validation-rendering-binding-behavior.js
+++ b/dist/system/validation-rendering-binding-behavior.js
@@ -1,0 +1,81 @@
+'use strict';
+
+System.register(['./validation-renderer', 'aurelia-dependency-injection', './validation-engine'], function (_export, _context) {
+  var ValidationRenderer, inject, ValidationEngine, _dec, _class, ValidationRenderingBindingBehavior;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  return {
+    setters: [function (_validationRenderer) {
+      ValidationRenderer = _validationRenderer.ValidationRenderer;
+    }, function (_aureliaDependencyInjection) {
+      inject = _aureliaDependencyInjection.inject;
+    }, function (_validationEngine) {
+      ValidationEngine = _validationEngine.ValidationEngine;
+    }],
+    execute: function () {
+      _export('ValidationRenderingBindingBehavior', ValidationRenderingBindingBehavior = (_dec = inject(ValidationRenderer), _dec(_class = function () {
+        function ValidationRenderingBindingBehavior(renderer) {
+          _classCallCheck(this, ValidationRenderingBindingBehavior);
+
+          this.renderer = renderer;
+          this.liveBinding = false;
+        }
+
+        ValidationRenderingBindingBehavior.prototype.bind = function bind(binding, source) {
+          var _this = this;
+
+          var targetProperty = void 0;
+          var target = void 0;
+          var reporter = void 0;
+          source._dirty = false;
+          binding.target.addEventListener('focus', function (event) {
+            source._dirty = true;
+          });
+          targetProperty = this.getTargetProperty(binding);
+          target = this.getTargetObject(binding);
+          reporter = ValidationEngine.getOrCreateValidationReporter(target);
+          reporter.subscribe(function (errors, pushRendering) {
+            var relevantErrors = errors.filter(function (error) {
+              return error.propertyName === targetProperty;
+            });
+            if (_this.liveBinding && source._dirty || pushRendering) _this.renderer.renderErrors(binding.target, relevantErrors);
+          });
+        };
+
+        ValidationRenderingBindingBehavior.prototype.unbind = function unbind(binding, source) {};
+
+        ValidationRenderingBindingBehavior.prototype.getTargetProperty = function getTargetProperty(binding) {
+          var targetProperty = void 0;
+          if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+            targetProperty = binding.sourceExpression.expression.name;
+          }
+          return targetProperty;
+        };
+
+        ValidationRenderingBindingBehavior.prototype.getTargetObject = function getTargetObject(binding) {
+          var targetObject = void 0;
+          if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+            targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+          } else {
+            targetObject = binding.source.bindingContext;
+          }
+          return targetObject;
+        };
+
+        ValidationRenderingBindingBehavior.prototype.getPropertyContext = function getPropertyContext(source, targetProperty) {
+          var target = getContextFor(source, targetProperty);
+          return target;
+        };
+
+        return ValidationRenderingBindingBehavior;
+      }()) || _class));
+
+      _export('ValidationRenderingBindingBehavior', ValidationRenderingBindingBehavior);
+    }
+  };
+});

--- a/dist/system/validation-reporter.js
+++ b/dist/system/validation-reporter.js
@@ -50,7 +50,7 @@ System.register([], function (_export, _context) {
           return observer;
         };
 
-        ValidationReporter.prototype.publish = function publish(errors) {
+        ValidationReporter.prototype.publish = function publish(errors, pushRendering) {
           for (var _iterator = Object.keys(this.__callbacks__), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
             var _ref;
 
@@ -66,7 +66,7 @@ System.register([], function (_export, _context) {
             var key = _ref;
 
             var observer = this.__callbacks__[key];
-            observer.callback(errors);
+            observer.callback(errors, pushRendering);
           }
         };
 

--- a/dist/system/validation-rule.js
+++ b/dist/system/validation-rule.js
@@ -68,6 +68,14 @@ System.register(['validate.js', 'aurelia-validation'], function (_export, _conte
         };
 
         ValidationRule.format = function format(config) {
+          if (config instanceof RegExp) {
+            var pattern = config.toString();
+            pattern = pattern.substr(1, pattern.length - 2);
+            config = {
+              pattern: pattern
+            };
+          }
+
           return new ValidationRule('format', config);
         };
 
@@ -95,6 +103,17 @@ System.register(['validate.js', 'aurelia-validation'], function (_export, _conte
           var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
           return new ValidationRule('url', config);
+        };
+
+        ValidationRule.custom = function custom() {
+          var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+          var name = arguments[1];
+
+          if (Reflect.has(config, "name")) {
+            return new ValidationRule(config.name, config.config);
+          } else {
+            return new ValidationRule(name, config);
+          }
         };
 
         return ValidationRule;

--- a/dist/system/validation-ruleset.js
+++ b/dist/system/validation-ruleset.js
@@ -1,0 +1,139 @@
+'use strict';
+
+System.register(['./validation-rule', './validation-engine', 'aurelia-metadata', './metadata-key'], function (_export, _context) {
+  var ValidationRule, ValidationEngine, metadata, validationMetadataKey, ValidationRuleset;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  return {
+    setters: [function (_validationRule) {
+      ValidationRule = _validationRule.ValidationRule;
+    }, function (_validationEngine) {
+      ValidationEngine = _validationEngine.ValidationEngine;
+    }, function (_aureliaMetadata) {
+      metadata = _aureliaMetadata.metadata;
+    }, function (_metadataKey) {
+      validationMetadataKey = _metadataKey.validationMetadataKey;
+    }],
+    execute: function () {
+      _export('ValidationRuleset', ValidationRuleset = function () {
+        function ValidationRuleset() {
+          _classCallCheck(this, ValidationRuleset);
+
+          this.__validationRules__ = [];
+        }
+
+        ValidationRuleset.for = function _for(object) {
+          return new Validator(object);
+        };
+
+        ValidationRuleset.prototype.addRule = function addRule(key, rule) {
+          this.__validationRules__.push({ key: key, rule: rule });
+        };
+
+        ValidationRuleset.prototype.validate = function validate(instance, property, _pushRendering) {
+          var errors = [];
+
+          var reporter = ValidationEngine.getValidationReporter(instance);
+          this.__validationRules__.forEach(function (rule) {
+            if (!property || property === rule.key) {
+              var result = rule.rule.validate(instance, rule.key);
+              if (result) {
+                errors.push(result);
+              }
+            }
+          });
+
+          if (reporter) reporter.publish(errors, _pushRendering);
+          return errors;
+        };
+
+        ValidationRuleset.prototype[Symbol.iterator] = function () {
+          return this.__validationRules__[Symbol.iterator]();
+        };
+
+        ValidationRuleset.getDecoratorsRuleset = function getDecoratorsRuleset(instance) {
+          var prototypeRuleset = metadata.get(validationMetadataKey, instance);
+          if (prototypeRuleset) {
+            return prototypeRuleset;
+          } else {
+            return undefined;
+          }
+        };
+
+        ValidationRuleset.prototype.ensure = function ensure(property) {
+          this.currentProperty = property;
+          return this;
+        };
+
+        ValidationRuleset.prototype.length = function length(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.lengthRule(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.presence = function presence(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.presence(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.required = function required(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.presence(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.numericality = function numericality(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.numericality(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.date = function date(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.date(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.datetime = function datetime(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.datetime(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.email = function email(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.email(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.equality = function equality(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.equality(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.format = function format(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.format(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.inclusion = function inclusion(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.inclusion(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.exclusion = function exclusion(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.exclusion(configuration));
+          return this;
+        };
+
+        ValidationRuleset.prototype.url = function url(configuration) {
+          this.addRule(this.currentProperty, ValidationRule.url(configuration));
+          return this;
+        };
+
+        return ValidationRuleset;
+      }());
+
+      _export('ValidationRuleset', ValidationRuleset);
+    }
+  };
+});

--- a/dist/system/validator-lite.js
+++ b/dist/system/validator-lite.js
@@ -1,0 +1,106 @@
+'use strict';
+
+System.register(['./validation-ruleset', './validation-rule', './validation-engine'], function (_export, _context) {
+  var ValidationRuleset, ValidationRule, ValidationEngine, ValidatorLite;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+    }
+
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
+    });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+  }
+
+  return {
+    setters: [function (_validationRuleset) {
+      ValidationRuleset = _validationRuleset.ValidationRuleset;
+    }, function (_validationRule) {
+      ValidationRule = _validationRule.ValidationRule;
+    }, function (_validationEngine) {
+      ValidationEngine = _validationEngine.ValidationEngine;
+    }],
+    execute: function () {
+      _export('ValidatorLite', ValidatorLite = function (_ValidationRuleset) {
+        _inherits(ValidatorLite, _ValidationRuleset);
+
+        function ValidatorLite(targetObject) {
+          _classCallCheck(this, ValidatorLite);
+
+          var _this = _possibleConstructorReturn(this, _ValidationRuleset.call(this));
+
+          _this.targetObject = targetObject;
+          return _this;
+        }
+
+        ValidatorLite.prototype.addRule = function addRule(key, rule) {
+          _ValidationRuleset.prototype.addRule.call(this, key, rule);
+        };
+
+        ValidatorLite.prototype.importRuleset = function importRuleset(ruleset) {
+          for (var _iterator = ruleset, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+            var _ref;
+
+            if (_isArray) {
+              if (_i >= _iterator.length) break;
+              _ref = _iterator[_i++];
+            } else {
+              _i = _iterator.next();
+              if (_i.done) break;
+              _ref = _i.value;
+            }
+
+            var rule = _ref;
+
+            this.addRule(rule.key, new ValidationRule(rule.rule.name, JSON.parse(JSON.stringify(rule.rule.config))));
+          }
+        };
+
+        ValidatorLite.prototype.getProperties = function getProperties() {
+          console.error('Not yet implemented');
+        };
+
+        ValidatorLite.for = function _for(object) {
+          return new ValidatorLite(object);
+        };
+
+        ValidatorLite.prototype.validate = function validate(property) {
+          if (property) {
+            return _ValidationRuleset.prototype.validate.call(this, this.targetObject, property, true);
+          } else {
+            return _ValidationRuleset.prototype.validate.call(this, this.targetObject, null, true);
+          }
+        };
+
+        ValidatorLite.prototype.getValidationReporter = function getValidationReporter() {
+          return ValidationEngine.getOrCreateValidationReporter(this.targetObject);
+        };
+
+        return ValidatorLite;
+      }(ValidationRuleset));
+
+      _export('ValidatorLite', ValidatorLite);
+    }
+  };
+});

--- a/dist/system/validator.js
+++ b/dist/system/validator.js
@@ -1,7 +1,7 @@
 'use strict';
 
-System.register(['./metadata-key', './validation-config', './validation-engine', './validation-rule', 'aurelia-metadata'], function (_export, _context) {
-  var validationMetadataKey, ValidationConfig, ValidationEngine, ValidationRule, metadata, Validator;
+System.register(['aurelia-metadata', './validation-ruleset', './validation-engine', './metadata-key', './property-observer'], function (_export, _context) {
+  var metadata, ValidationRuleset, ValidationEngine, validationMetadataKey, observeProperty, Validator;
 
   function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
@@ -9,109 +9,74 @@ System.register(['./metadata-key', './validation-config', './validation-engine',
     }
   }
 
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+    }
+
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
+    });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+  }
+
   return {
-    setters: [function (_metadataKey) {
-      validationMetadataKey = _metadataKey.validationMetadataKey;
-    }, function (_validationConfig) {
-      ValidationConfig = _validationConfig.ValidationConfig;
+    setters: [function (_aureliaMetadata) {
+      metadata = _aureliaMetadata.metadata;
+    }, function (_validationRuleset) {
+      ValidationRuleset = _validationRuleset.ValidationRuleset;
     }, function (_validationEngine) {
       ValidationEngine = _validationEngine.ValidationEngine;
-    }, function (_validationRule) {
-      ValidationRule = _validationRule.ValidationRule;
-    }, function (_aureliaMetadata) {
-      metadata = _aureliaMetadata.metadata;
+    }, function (_metadataKey) {
+      validationMetadataKey = _metadataKey.validationMetadataKey;
+    }, function (_propertyObserver) {
+      observeProperty = _propertyObserver.observeProperty;
     }],
     execute: function () {
-      _export('Validator', Validator = function () {
-        function Validator(object) {
+      _export('Validator', Validator = function (_ValidatorLite) {
+        _inherits(Validator, _ValidatorLite);
+
+        function Validator(targetObject) {
           _classCallCheck(this, Validator);
 
-          this.object = object;
+          var _this = _possibleConstructorReturn(this, _ValidatorLite.call(this, targetObject));
+
+          var prototypeRuleset = ValidationRuleset.getDecoratorsRuleset(targetObject);
+          if (prototypeRuleset) {
+            _this.importRuleset(prototypeRuleset);
+          }
+          return _this;
         }
 
-        Validator.prototype.validate = function validate(prop) {
-          var config = metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, this.object);
-          var reporter = ValidationEngine.getValidationReporter(this.object);
-          if (prop) {
-            config.validate(this.object, reporter, prop);
-          } else {
-            config.validate(this.object, reporter);
-          }
+        Validator.prototype.addRule = function addRule(key, rule) {
+          _ValidatorLite.prototype.addRule.call(this, key, rule);
+          observeProperty(this.targetObject, key, undefined, null, rule, this);
         };
 
-        Validator.prototype.getProperties = function getProperties() {
-          console.error('Not yet implemented');
+        Validator.for = function _for(object) {
+          return new Validator(object);
         };
 
-        Validator.prototype.ensure = function ensure(prop) {
-          var config = metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, this.object);
-          this.config = config;
-          this.currentProperty = prop;
-          return this;
-        };
-
-        Validator.prototype.length = function length(configuration) {
-          this.config.addRule(this.currentProperty, ValidationRule.lengthRule(configuration));
-          return this;
-        };
-
-        Validator.prototype.presence = function presence() {
-          this.config.addRule(this.currentProperty, ValidationRule.presence());
-          return this;
-        };
-
-        Validator.prototype.required = function required() {
-          this.config.addRule(this.currentProperty, ValidationRule.presence());
-          return this;
-        };
-
-        Validator.prototype.numericality = function numericality() {
-          this.config.addRule(this.currentProperty, ValidationRule.numericality());
-          return this;
-        };
-
-        Validator.prototype.date = function date() {
-          this.config.addRule(this.currentProperty, ValidationRule.date());
-          return this;
-        };
-
-        Validator.prototype.datetime = function datetime() {
-          this.config.addRule(this.currentProperty, ValidationRule.datetime());
-          return this;
-        };
-
-        Validator.prototype.email = function email() {
-          this.config.addRule(this.currentProperty, ValidationRule.email());
-          return this;
-        };
-
-        Validator.prototype.equality = function equality(configuration) {
-          this.config.addRule(this.currentProperty, ValidationRule.equality(configuration));
-          return this;
-        };
-
-        Validator.prototype.format = function format(configuration) {
-          this.config.addRule(this.currentProperty, ValidationRule.format(configuration));
-          return this;
-        };
-
-        Validator.prototype.inclusion = function inclusion(configuration) {
-          this.config.addRule(this.currentProperty, ValidationRule.inclusion(configuration));
-          return this;
-        };
-
-        Validator.prototype.exclusion = function exclusion(configuration) {
-          this.config.addRule(this.currentProperty, ValidationRule.exclusion(configuration));
-          return this;
-        };
-
-        Validator.prototype.url = function url() {
-          this.config.addRule(this.currentProperty, ValidationRule.url());
-          return this;
+        Validator.prototype.validate = function validate(property) {
+          ValidationEngine.ensureValidationReporter(this.targetObject);
+          return _ValidatorLite.prototype.validate.call(this, property);
         };
 
         return Validator;
-      }());
+      }(ValidatorLite));
 
       _export('Validator', Validator);
     }

--- a/sample/src/decorators.html
+++ b/sample/src/decorators.html
@@ -8,75 +8,76 @@
     <div>
       <label class="form-group">
         <strong>First Name</strong>
-        <input class="form-control" value.bind="model.firstName & validate" />
+        <input class="form-control" value.bind="model.firstName & liveValidationRendering" />
       </label>
     </div>
     <div>
       <label class="form-group" with.bind="model">
         <strong>Last Name</strong>
-        <input class="form-control" value.bind="lastName & validate" />
+        <input class="form-control" value.bind="lastName & liveValidationRendering" />
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Last Updated</strong>
-        <input type="date" class="form-control" value.bind="model.lastUpdated & validate"/>
+        <input type="date" class="form-control" value.bind="model.lastUpdated & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Last Time Updated</strong>
-        <input type="datetime" class="form-control" value.bind="model.lastTimeUpdated & validate"/>
+        <input type="datetime" class="form-control" value.bind="model.lastTimeUpdated & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Email</strong>
-        <input class="form-control" value.bind="model.email & validate"/>
+        <input class="form-control" value.bind="model.email & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Password</strong>
-        <input type="password" class="form-control" value.bind="model.password & validate"/>
+        <input type="password" class="form-control" value.bind="model.password & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Confirm Password</strong>
-        <input type="password" class="form-control" value.bind="model.confirmPassword & validate"/>
+        <input type="password" class="form-control" value.bind="model.confirmPassword & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Website</strong>
-        <input class="form-control" value.bind="model.website & validate"/>
+        <input class="form-control" value.bind="model.website & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Age</strong>
-        <input class="form-control" value.bind="model.age & validate"/>
+        <input class="form-control" value.bind="model.age & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Gender</strong>
-        <input class="form-control" value.bind="model.gender & validate"/>
+        <input class="form-control" value.bind="model.gender & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Blue or Red?</strong>
-        <input class="form-control" value.bind="model.blueOrRed & validate"/>
+        <input class="form-control" value.bind="model.blueOrRed & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Zip Code</strong>
-        <input class="form-control" value.bind="model.zipCode & validate"/>
+        <input class="form-control" value.bind="model.zipCode & liveValidationRendering"/>
       </label>
     </div>
+    <button click.trigger="addValidator()">Add Validator & Rule</button>
     <button click.trigger="submit()">Submit</button>
   </form>
 </template>

--- a/sample/src/fluent.html
+++ b/sample/src/fluent.html
@@ -8,75 +8,76 @@
     <div>
       <label class="form-group">
         <strong>First Name</strong>
-        <input class="form-control" value.bind="model.firstName & validate" />
+        <input class="form-control" value.bind="model.firstName & liveValidationRendering" />
       </label>
     </div>
     <div>
       <label class="form-group" with.bind="model">
         <strong>Last Name</strong>
-        <input class="form-control" value.bind="lastName & validate" />
+        <input class="form-control" value.bind="lastName & liveValidationRendering" />
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Last Updated</strong>
-        <input type="date" class="form-control" value.bind="model.lastUpdated & validate"/>
+        <input type="date" class="form-control" value.bind="model.lastUpdated & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Last Time Updated</strong>
-        <input type="datetime" class="form-control" value.bind="model.lastTimeUpdated & validate"/>
+        <input type="datetime" class="form-control" value.bind="model.lastTimeUpdated & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Email</strong>
-        <input class="form-control" value.bind="model.email & validate"/>
+        <input class="form-control" value.bind="model.email & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Password</strong>
-        <input type="password" class="form-control" value.bind="model.password & validate"/>
+        <input type="password" class="form-control" value.bind="model.password & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Confirm Password</strong>
-        <input type="password" class="form-control" value.bind="model.confirmPassword & validate"/>
+        <input type="password" class="form-control" value.bind="model.confirmPassword & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Website</strong>
-        <input class="form-control" value.bind="model.website & validate"/>
+        <input class="form-control" value.bind="model.website & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Age</strong>
-        <input class="form-control" value.bind="model.age & validate"/>
+        <input class="form-control" value.bind="model.age & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Gender</strong>
-        <input class="form-control" value.bind="model.gender & validate"/>
+        <input class="form-control" value.bind="model.gender & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Blue or Red?</strong>
-        <input class="form-control" value.bind="model.blueOrRed & validate"/>
+        <input class="form-control" value.bind="model.blueOrRed & liveValidationRendering"/>
       </label>
     </div>
     <div>
       <label class="form-group">
         <strong>Zip Code</strong>
-        <input class="form-control" value.bind="model.zipCode & validate"/>
+        <input class="form-control" value.bind="model.zipCode & liveValidationRendering"/>
       </label>
     </div>
+    <button click.trigger="addValidatorLite()">Add Second Model & ValidatorLite</button>
     <button click.trigger="validate()">Validate</button>
   </form>
 </template>

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -48,3 +48,11 @@ export function url(targetOrConfig, key, descriptor) {
 export function numericality(targetOrConfig, key, descriptor) {
   return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
 }
+
+export function custom(name, targetOrConfig, key, descriptor) {
+  targetOrConfig = {
+    name: name,
+    config: targetOrConfig === undefined ? true : targetOrConfig
+  }
+  return base(targetOrConfig, key, descriptor, ValidationRule.custom);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
-export {length, required, date, datetime, email, equality, exclusion, inclusion, format, url, numericality} from './decorators';
+export {length, required, date, datetime, email, equality, exclusion, inclusion, format, url, numericality, custom} from './decorators';
 export {ValidationEngine} from './validation-engine';
 import {Validator} from 'aurelia-validation';
 import {Validator as ValidateJSValidator} from './validator';
 export {Validator} from './validator';
+export {ValidatorLite} from './validator-lite';
+export {ValidationRuleset} from './validation-ruleset';
 import {ValidationReporter} from 'aurelia-validation';
 import {ValidationReporter as ValidateJSReporter} from './validation-reporter';
 export {ValidationReporter} from './validation-reporter';
@@ -11,5 +13,6 @@ export {ValidationRenderer} from './validation-renderer';
 export function configure(config) {
   config.container.registerHandler(Validator, ValidateJSValidator);
   config.container.registerHandler(ValidationReporter, ValidateJSReporter);
-  config.globalResources('./validate-binding-behavior');
+  config.globalResources('./validation-rendering-binding-behavior');
+  config.globalResources('./live-validation-rendering-binding-behavior');
 }

--- a/src/live-validation-rendering-binding-behavior.js
+++ b/src/live-validation-rendering-binding-behavior.js
@@ -1,0 +1,58 @@
+import {ValidationRenderer} from './validation-renderer';
+import {inject} from 'aurelia-dependency-injection';
+import {ValidationEngine} from './validation-engine';
+
+@inject(ValidationRenderer)
+export class LiveValidationRenderingBindingBehavior {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.liveBinding = true;
+  }
+  
+  bind(binding, source) {
+    let targetProperty;
+    let target;
+    let reporter;
+    //capture the focus event on the element, so we know if we should start rendering validation errors.
+    binding.target._dirty = false;
+    binding.target.addEventListener('focus', (event) => { binding.target._dirty = true; });
+    targetProperty = this.getTargetProperty(binding);
+    target = this.getTargetObject(binding);
+    reporter = ValidationEngine.getOrCreateValidationReporter(target);
+    reporter.subscribe((errors, pushRendering) => {
+      let relevantErrors = errors.filter(error => {
+        return error.propertyName === targetProperty;
+      });
+      //only render errors if they have been pushed by a method call, or the user has touched the field.
+      if ((this.liveBinding && binding.target._dirty) || pushRendering)
+        this.renderer.renderErrors(binding.target, relevantErrors);
+    });
+  }
+  
+  unbind(binding, source) {
+    // let targetProperty = this.getTargetProperty(source);
+    // let target = this.getPropertyContext(source, targetProperty);
+    // let reporter = this.getReporter(source);
+  }
+  
+  getTargetProperty(binding) {
+    let targetProperty;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+      targetProperty = binding.sourceExpression.expression.name;
+    }
+    return targetProperty;
+  }
+  getTargetObject(binding) {
+    let targetObject;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+      targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+    }  else {
+      targetObject = binding.source.bindingContext;
+    }
+    return targetObject;
+  }
+  getPropertyContext(source, targetProperty) {
+    let target = getContextFor(source, targetProperty);
+    return target;
+  }
+}

--- a/src/property-observer.js
+++ b/src/property-observer.js
@@ -1,15 +1,34 @@
 import {metadata} from 'aurelia-metadata';
-import {ValidationConfig} from './validation-config';
+import {ValidationRuleset} from './validation-ruleset';
 import {ValidationEngine} from './validation-engine';
 import {validationMetadataKey} from './metadata-key';
+import {ValidationRule} from './validation-rule';
 
-export function observeProperty(target, key, descriptor, targetOrConfig, rule) {
-  let config = metadata.getOrCreateOwn(validationMetadataKey, ValidationConfig, target);
-  config.addRule(key, rule(targetOrConfig));
+export function observeProperty(target, key, descriptor, targetOrConfig, rule, ruleset) {
+  // if rule is an existing instance, we know we came from the Validator, rather than the decorators.
+  if (rule instanceof ValidationRule) {
+    //avoid inserting properties that do not exist. - Possible problem if the property is added later?
+    if (!Reflect.has(target, key)) {
+      return;
+    }
+  } else {
+    // get ruleset from metatdata
+    ruleset = metadata.getOrCreateOwn(validationMetadataKey, ValidationRuleset, target);
+    ruleset.addRule(key, rule(targetOrConfig));
+  }
 
   // TODO: REMOVE
   let innerPropertyName = `_${key}`;
-
+  
+  //Check if we've already intercepted a specific property
+  let existingDescriptor = Object.getOwnPropertyDescriptor(target, key);
+  let alreadyIntercepted = ((existingDescriptor !== undefined) && (existingDescriptor.get !== undefined) && existingDescriptor.get.generatedBy == "au-validation")
+  //capture any existing value, otherwise it disappears when we redefine the property
+  let instanceValue = ((existingDescriptor !== undefined) && (existingDescriptor.value !== undefined) ? existingDescriptor.value : undefined)
+  if (instanceValue === undefined) {
+    instanceValue = target[key];
+  }
+  
   // typescript or babel?
   let babel = descriptor !== undefined;
 
@@ -26,19 +45,25 @@ export function observeProperty(target, key, descriptor, targetOrConfig, rule) {
 
   delete descriptor.writable;
   delete descriptor.initializer;
-
+  
   descriptor.get = function() { return this[innerPropertyName]; };
   descriptor.set = function(newValue) {
-    let reporter = ValidationEngine.getValidationReporter(this);
+    ValidationEngine.ensureValidationReporter(this);
 
     this[innerPropertyName] = newValue;
 
-    config.validate(this, reporter);
+    //ensure we always call the basic ruleset validation method (rather than the validator classes methods)
+    ValidationRuleset.prototype.validate.call(ruleset, this);
   };
 
   descriptor.get.dependencies = [innerPropertyName];
-
-  if (!babel) {
+  //tag the descriptor s we know we generated it.
+  descriptor.get.generatedBy = "au-validation";
+  
+  if (!babel && !alreadyIntercepted) {
     Reflect.defineProperty(target, key, descriptor);
+    if (instanceValue) {
+      target[innerPropertyName] = instanceValue;
+    }
   }
 }

--- a/src/validation-engine.js
+++ b/src/validation-engine.js
@@ -2,6 +2,16 @@ import {ValidationReporter} from './validation-reporter';
 
 export class ValidationEngine {
   static getValidationReporter(instance) {
-    return instance.__validationReporter__ || (instance.__validationReporter__ = new ValidationReporter());
+    return instance.__validationReporter__
+  }
+  
+  static ensureValidationReporter(instance) {
+    if (!instance.__validationReporter__)
+      instance.__validationReporter__ = new ValidationReporter();
+  }
+  
+  static getOrCreateValidationReporter(instance) {
+    ValidationEngine.ensureValidationReporter(instance);
+    return ValidationEngine.getValidationReporter(instance);
   }
 }

--- a/src/validation-renderer.js
+++ b/src/validation-renderer.js
@@ -3,18 +3,21 @@ import {DOM} from 'aurelia-pal';
 export class ValidationRenderer {
   renderErrors(node, relevantErrors) {
     if (relevantErrors.length) {
+      this.unrenderErrors(node);
       node.parentElement.classList.add('has-error');
       relevantErrors.forEach(error => {
         if (node.parentElement.textContent.indexOf(error.message) === -1) {
           let errorMessageHelper = DOM.createElement('span');
           let errorMessageNode = DOM.createTextNode(error.message);
           errorMessageHelper.appendChild(errorMessageNode);
-          errorMessageHelper.classList.add('help-block');
+          errorMessageHelper.classList.add('help-block', 'au-validation');
           node.parentElement.appendChild(errorMessageHelper);
         }
       });
     } else {
-      this.unrenderErrors(node);
+      if (node.parentElement.classList.contains('has-error')) {
+        this.unrenderErrors(node);
+      }
     }
   }
   unrenderErrors(node) {
@@ -23,7 +26,7 @@ export class ValidationRenderer {
     let children = node.parentElement.children;
     for (let i = 0; i < children.length; i++) {
       let child = children[i];
-      if (child.classList.contains('help-block')) {
+      if (child.classList.contains('help-block') && child.classList.contains('au-validation')) {
         deleteThese.push(child);
       }
     }

--- a/src/validation-rendering-binding-behavior.js
+++ b/src/validation-rendering-binding-behavior.js
@@ -1,0 +1,58 @@
+import {ValidationRenderer} from './validation-renderer';
+import {inject} from 'aurelia-dependency-injection';
+import {ValidationEngine} from './validation-engine';
+
+// See comments on live validation behavior.  Only difference is this will never live render validations
+// want to inherit classes, but not possible within framework, and I don't know how to do a mixin :)
+@inject(ValidationRenderer)
+export class ValidationRenderingBindingBehavior {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.liveBinding = false;
+  }
+  
+  bind(binding, source) {
+    let targetProperty;
+    let target;
+    let reporter;
+    source._dirty = false;
+    binding.target.addEventListener('focus', (event) => { source._dirty = true; });
+    targetProperty = this.getTargetProperty(binding);
+    target = this.getTargetObject(binding);
+    reporter = ValidationEngine.getOrCreateValidationReporter(target);
+    reporter.subscribe((errors, pushRendering) => {
+      let relevantErrors = errors.filter(error => {
+        return error.propertyName === targetProperty;
+      });
+      if ((this.liveBinding && source._dirty) || pushRendering)
+        this.renderer.renderErrors(binding.target, relevantErrors);
+    });
+  }
+   
+  unbind(binding, source) {
+    // let targetProperty = this.getTargetProperty(source);
+    // let target = this.getPropertyContext(source, targetProperty);
+    // let reporter = this.getReporter(source);
+  }
+  
+  getTargetProperty(binding) {
+    let targetProperty;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.name) {
+      targetProperty = binding.sourceExpression.expression.name;
+    }
+    return targetProperty;
+  }
+  getTargetObject(binding) {
+    let targetObject;
+    if (binding.sourceExpression && binding.sourceExpression.expression && binding.sourceExpression.expression.object) {
+      targetObject = binding.source.bindingContext[binding.sourceExpression.expression.object.name];
+    }  else {
+      targetObject = binding.source.bindingContext;
+    }
+    return targetObject;
+  }
+  getPropertyContext(source, targetProperty) {
+    let target = getContextFor(source, targetProperty);
+    return target;
+  }
+}

--- a/src/validation-reporter.js
+++ b/src/validation-reporter.js
@@ -25,10 +25,10 @@ export class ValidationReporter {
     this.__callbacks__[observer.id] = observer;
     return observer;
   }
-  publish(errors) {
+  publish(errors, pushRendering) {
     for (let key of Object.keys(this.__callbacks__)) {
       let observer = this.__callbacks__[key];
-      observer.callback(errors);
+      observer.callback(errors, pushRendering);
     }
   }
   destroyObserver(observer) {

--- a/src/validation-rule.js
+++ b/src/validation-rule.js
@@ -35,7 +35,16 @@ export class ValidationRule {
   static exclusion(config) {
     return new ValidationRule('exclusion', config);
   }
+  //ensures regex can be cloned by JSON/JSON approach.
   static format(config) {
+    if (config instanceof RegExp) {
+      let pattern = config.toString();
+      pattern = pattern.substr(1, pattern.length - 2);
+      config = {
+        pattern: pattern
+      }
+    }
+      
     return new ValidationRule('format', config);
   }
   static inclusion(config) {
@@ -52,6 +61,14 @@ export class ValidationRule {
   }
   static url(config = true) {
     return new ValidationRule('url', config);
+  }
+  
+  static custom(config = true, name) {
+    if (Reflect.has(config, "name")) {
+      return new ValidationRule(config.name, config.config);
+    } else {
+      return new ValidationRule(name, config);
+    }
   }
 }
 

--- a/src/validation-ruleset.js
+++ b/src/validation-ruleset.js
@@ -1,0 +1,103 @@
+import {ValidationRule} from './validation-rule';
+import {ValidationEngine} from './validation-engine';
+import {metadata} from 'aurelia-metadata';
+import {validationMetadataKey} from './metadata-key';
+
+//Seperate validation rulset
+//Can be used independently to build a list of rules, and to validate any object
+export class ValidationRuleset
+{
+  static for(object) {
+    return new Validator(object);
+  }
+  
+  __validationRules__ = [];
+  
+  addRule(key, rule) {
+    this.__validationRules__.push({ key: key, rule: rule });
+  }
+  
+  validate(instance, property, _pushRendering) {
+    let errors = [];
+    //Only gets reporter if one already exists.
+    let reporter = ValidationEngine.getValidationReporter(instance);
+    this.__validationRules__.forEach(rule => {
+      if (!property || property === rule.key) {
+        let result = rule.rule.validate(instance, rule.key);
+        if (result) {
+          errors.push(result);
+        }
+      }
+    });
+    //only publishes errors if it finds an existing reporter.  Always returns errors though.
+    if (reporter)
+      reporter.publish(errors, _pushRendering);
+    return errors;
+  }
+  
+  [Symbol.iterator]() {
+      return this.__validationRules__[Symbol.iterator]();
+  }
+  
+  static getDecoratorsRuleset(instance) {
+    let prototypeRuleset = metadata.get(validationMetadataKey, instance);
+    if (prototypeRuleset) {
+      return prototypeRuleset;
+    } else {
+      return undefined;
+    }
+  }
+  
+  ensure(property) {
+    this.currentProperty = property;
+    return this;
+  }
+  length(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.lengthRule(configuration));
+    return this;
+  }
+  presence(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.presence(configuration));
+    return this;
+  }
+  required(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.presence(configuration));
+    return this;
+  }
+  numericality(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.numericality(configuration));
+    return this;
+  }
+  date(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.date(configuration));
+    return this;
+  }
+  datetime(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.datetime(configuration));
+    return this;
+  }
+  email(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.email(configuration));
+    return this;
+  }
+  equality(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.equality(configuration));
+    return this;
+  }
+  format(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.format(configuration));
+    return this;
+  }
+  inclusion(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.inclusion(configuration));
+    return this;
+  }
+  exclusion(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.exclusion(configuration));
+    return this;
+  }
+  url(configuration) {
+    this.addRule(this.currentProperty, ValidationRule.url(configuration));
+    return this;
+  }
+}

--- a/src/validator-lite.js
+++ b/src/validator-lite.js
@@ -1,0 +1,46 @@
+import {ValidationRuleset} from './validation-ruleset';
+import {ValidationRule} from './validation-rule';
+import {ValidationEngine} from './validation-engine';
+
+
+//light weight instance validator.
+//does not import prototype rules, does not observeproperties.
+//only method for validation is calling validate method.
+//Will report via ValidationReporter if getValidationReporter() has previously been called.
+export class ValidatorLite extends ValidationRuleset {
+    
+  constructor(targetObject) {
+    super();
+    this.targetObject = targetObject;
+  }
+  
+  addRule(key, rule) {
+    super.addRule(key,rule);
+  }
+  
+  importRuleset(ruleset) {
+    for (var rule of ruleset) {
+      this.addRule(rule.key, new ValidationRule(rule.rule.name, JSON.parse(JSON.stringify(rule.rule.config))));
+    }
+  }
+  
+  getProperties() {
+    console.error('Not yet implemented');
+  }
+  
+  static for(object) {
+      return new ValidatorLite(object);
+  }
+  
+  validate(property) {
+    if (property) {
+      return super.validate(this.targetObject, property, true);
+    } else {
+      return super.validate(this.targetObject, null, true);
+    }
+  }
+  
+  getValidationReporter() {
+    return ValidationEngine.getOrCreateValidationReporter(this.targetObject)
+  }
+}


### PR DESCRIPTION
Take 2... smaller PR with just the actual changed code... original PR message below... busy putting together a gist of the sample app.

Ok I know this is probably totally in poor taste, or against some ethics of git which I'm not really aware of... so my apologies, this was just one of those things where I wanted to have a play, and it all just got away from me. At this point it's just to initiate discussion, feedback etc.

So the run down...

- Refactored ValidationConfig into ValidationRuleset, standalone ruleset that can be used to validate any object against it's rules.
- Added ValidatorLite, instance specific validator, but never observes properties (so can't be used for live validation), or attempts to work with decorators.
- Refactored Validator to instance specific validator. Works on same principles as decorators, and automatically merges any decorator rules with it's own ruleset.
- Refactored binding behaviour into live binding, and plain rendering validation. Live binding will show errors only once user has touched field (based on focus event), or when pushed by manual validate call. Plain binding, will only show rules when pushed via manual validate call.
- Added custom validation rule allowing the use of custom rules registered with Validate.js.

Like I said, this is just a big experiment for me. Pushing this as a PR is also not a good idea, but I didn't really know how to point anyone to my fork.  I'd like any honest feedback on the +/- of this approach.

Oh and as @EisenbergEffect said he doesn't like inheritance, I doubt this will do anything to change hid mind :tired_face: