### PR TITLE
fix(dts): make key and descriptor optional

### DIFF
--- a/dist/aurelia-validatejs.d.ts
+++ b/dist/aurelia-validatejs.d.ts
@@ -107,5 +107,5 @@ declare module 'aurelia-validatejs' {
   export function inclusion(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function format(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function url(targetOrConfig?: any, key?: any, descriptor?: any): any;
-  export function numericality(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function numericality(targetOrConfig?: any, key?: any, descriptor?: any): any;
 }

--- a/dist/aurelia-validatejs.d.ts
+++ b/dist/aurelia-validatejs.d.ts
@@ -97,15 +97,15 @@ declare module 'aurelia-validatejs' {
   }
   export function base(targetOrConfig: any, key: any, descriptor: any, rule: any): any;
   export function length(targetOrConfig: any, key?: any, descriptor?: any): any;
-  export function presence(targetOrConfig: any, key?: any, descriptor?: any): any;
-  export function required(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function presence(targetOrConfig?: any, key?: any, descriptor?: any): any;
+  export function required(targetOrConfig?: any, key?: any, descriptor?: any): any;
   export function date(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function datetime(targetOrConfig: any, key?: any, descriptor?: any): any;
-  export function email(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function email(targetOrConfig?: any, key?: any, descriptor?: any): any;
   export function equality(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function exclusion(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function inclusion(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function format(targetOrConfig: any, key?: any, descriptor?: any): any;
-  export function url(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function url(targetOrConfig?: any, key?: any, descriptor?: any): any;
   export function numericality(targetOrConfig: any, key?: any, descriptor?: any): any;
 }

--- a/dist/aurelia-validatejs.d.ts
+++ b/dist/aurelia-validatejs.d.ts
@@ -96,16 +96,16 @@ declare module 'aurelia-validatejs' {
     url(configuration: any): any;
   }
   export function base(targetOrConfig: any, key: any, descriptor: any, rule: any): any;
-  export function length(targetOrConfig: any, key: any, descriptor: any): any;
-  export function presence(targetOrConfig: any, key: any, descriptor: any): any;
-  export function required(targetOrConfig: any, key: any, descriptor: any): any;
-  export function date(targetOrConfig: any, key: any, descriptor: any): any;
-  export function datetime(targetOrConfig: any, key: any, descriptor: any): any;
-  export function email(targetOrConfig: any, key: any, descriptor: any): any;
-  export function equality(targetOrConfig: any, key: any, descriptor: any): any;
-  export function exclusion(targetOrConfig: any, key: any, descriptor: any): any;
-  export function inclusion(targetOrConfig: any, key: any, descriptor: any): any;
-  export function format(targetOrConfig: any, key: any, descriptor: any): any;
-  export function url(targetOrConfig: any, key: any, descriptor: any): any;
-  export function numericality(targetOrConfig: any, key: any, descriptor: any): any;
+  export function length(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function presence(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function required(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function date(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function datetime(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function email(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function equality(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function exclusion(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function inclusion(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function format(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function url(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function numericality(targetOrConfig: any, key?: any, descriptor?: any): any;
 }

--- a/dist/aurelia-validatejs.d.ts
+++ b/dist/aurelia-validatejs.d.ts
@@ -99,8 +99,8 @@ declare module 'aurelia-validatejs' {
   export function length(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function presence(targetOrConfig?: any, key?: any, descriptor?: any): any;
   export function required(targetOrConfig?: any, key?: any, descriptor?: any): any;
-  export function date(targetOrConfig: any, key?: any, descriptor?: any): any;
-  export function datetime(targetOrConfig: any, key?: any, descriptor?: any): any;
+  export function date(targetOrConfig?: any, key?: any, descriptor?: any): any;
+  export function datetime(targetOrConfig?: any, key?: any, descriptor?: any): any;
   export function email(targetOrConfig?: any, key?: any, descriptor?: any): any;
   export function equality(targetOrConfig: any, key?: any, descriptor?: any): any;
   export function exclusion(targetOrConfig: any, key?: any, descriptor?: any): any;


### PR DESCRIPTION
The key and descriptor arguments on the decorator functions must be optional.