### PR TITLE
feat (aurelia-validatejs): custom validation rule support

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,26 @@ export class Model {
 }
 ```
 
+## Custom Validation rules
+
+```es6
+export function custRule(value,config){ ... }
+
+export class Model {
+  @registerCustomValidationRule({ruleName:'myRule', rule:custRule, config:{message:"try again",foo:"bar"}}) myProp = "Foobar!";
+  @registerCustomValidationRule({ruleName:'myRule2', rule:function(value,option){....}, config:{message:"try again",foo:"bar"}}) myProp2 = "Foobar!";
+}
+
+export class Model {
+  constructor() {
+    this.validator = new Validator(this)
+      .registerCustomValidationRule( 'myRule',custRule)
+      .registerCustomValidationRule( 'myRule2',function(value,option){....})
+      .ensure("myProp").required().myRule({message:"Incorrect value entered", });
+  }
+}
+```
+
 ## Building The Code
 
 To build the code, follow these steps.

--- a/dist/amd/aurelia-validatejs.js
+++ b/dist/amd/aurelia-validatejs.js
@@ -20,6 +20,7 @@ define(['exports', 'aurelia-metadata', 'aurelia-validation', 'validate.js'], fun
   exports.format = format;
   exports.url = url;
   exports.numericality = numericality;
+  exports.registerCustomValidationRule = registerCustomValidationRule;
   exports.configure = configure;
 
   var _validate3 = _interopRequireDefault(_validate2);
@@ -98,6 +99,26 @@ define(['exports', 'aurelia-metadata', 'aurelia-validation', 'validate.js'], fun
       var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
       return new ValidationRule('url', config);
+    };
+
+    ValidationRule.registerCustomValidationRule = function registerCustomValidationRule() {
+      var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+
+      var ruleName = config.ruleName;
+      var rule = config.rule;
+
+      _validate3.default.validators[ruleName] = rule;
+
+      ValidationRule[ruleName] = function (config) {
+        return new ValidationRule(ruleName, config);
+      };
+
+      ValidationRules[ruleName] = function (config) {
+        this.addRule(this.currentProperty, ValidationRule[ruleName](config));
+        return this;
+      };
+
+      return new ValidationRule(ruleName, config.config || true);
     };
 
     return ValidationRule;
@@ -209,6 +230,21 @@ define(['exports', 'aurelia-metadata', 'aurelia-validation', 'validate.js'], fun
       return this;
     };
 
+    ValidationRules.prototype.registerCustomValidationRule = function registerCustomValidationRule(ruleName, rule) {
+      _validate3.default.validators[ruleName] = rule;
+
+      ValidationRule[ruleName] = function (config) {
+        return new ValidationRule(ruleName, config);
+      };
+
+      this[ruleName] = function (configuration) {
+        this.addRule(this.currentProperty, ValidationRule[ruleName](configuration));
+        return this;
+      };
+
+      return this;
+    };
+
     return ValidationRules;
   }();
 
@@ -281,6 +317,10 @@ define(['exports', 'aurelia-metadata', 'aurelia-validation', 'validate.js'], fun
 
   function numericality(targetOrConfig, key, descriptor) {
     return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
+  }
+
+  function registerCustomValidationRule(targetOrConfig, key, descriptor) {
+    return base(targetOrConfig, key, descriptor, ValidationRule.registerCustomValidationRule);
   }
 
   var Validator = exports.Validator = function () {

--- a/dist/aurelia-validatejs.d.ts
+++ b/dist/aurelia-validatejs.d.ts
@@ -22,6 +22,7 @@ export declare class ValidationRule {
   static numericality(config?: any): any;
   static presence(config?: any): any;
   static url(config?: any): any;
+  static registerCustomValidationRule(config?: any): any;
 }
 export declare function cleanResult(data?: any): any;
 export declare class ValidationRules {
@@ -43,6 +44,7 @@ export declare class ValidationRules {
   inclusion(configuration?: any): any;
   exclusion(configuration?: any): any;
   url(configuration?: any): any;
+  registerCustomValidationRule(ruleName?: any, rule?: any): any;
 }
 export declare function base(targetOrConfig?: any, key?: any, descriptor?: any, rule?: any): any;
 export declare function addRule(target?: any, key?: any, descriptor?: any, targetOrConfig?: any, rule?: any): any;
@@ -58,6 +60,7 @@ export declare function inclusion(targetOrConfig?: any, key?: any, descriptor?: 
 export declare function format(targetOrConfig?: any, key?: any, descriptor?: any): any;
 export declare function url(targetOrConfig?: any, key?: any, descriptor?: any): any;
 export declare function numericality(targetOrConfig?: any, key?: any, descriptor?: any): any;
+export declare function registerCustomValidationRule(targetOrConfig?: any, key?: any, descriptor?: any): any;
 export declare class Validator {
   validateProperty(object?: any, propertyName?: any, rules?: any): any;
   validateObject(object?: any, rules?: any): any;

--- a/dist/commonjs/aurelia-validatejs.js
+++ b/dist/commonjs/aurelia-validatejs.js
@@ -19,6 +19,7 @@ exports.inclusion = inclusion;
 exports.format = format;
 exports.url = url;
 exports.numericality = numericality;
+exports.registerCustomValidationRule = registerCustomValidationRule;
 exports.configure = configure;
 
 var _aureliaMetadata = require('aurelia-metadata');
@@ -99,6 +100,26 @@ var ValidationRule = exports.ValidationRule = function () {
     var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
     return new ValidationRule('url', config);
+  };
+
+  ValidationRule.registerCustomValidationRule = function registerCustomValidationRule() {
+    var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+
+    var ruleName = config.ruleName;
+    var rule = config.rule;
+
+    _validate3.default.validators[ruleName] = rule;
+
+    ValidationRule[ruleName] = function (config) {
+      return new ValidationRule(ruleName, config);
+    };
+
+    ValidationRules[ruleName] = function (config) {
+      this.addRule(this.currentProperty, ValidationRule[ruleName](config));
+      return this;
+    };
+
+    return new ValidationRule(ruleName, config.config || true);
   };
 
   return ValidationRule;
@@ -210,6 +231,21 @@ var ValidationRules = exports.ValidationRules = function () {
     return this;
   };
 
+  ValidationRules.prototype.registerCustomValidationRule = function registerCustomValidationRule(ruleName, rule) {
+    _validate3.default.validators[ruleName] = rule;
+
+    ValidationRule[ruleName] = function (config) {
+      return new ValidationRule(ruleName, config);
+    };
+
+    this[ruleName] = function (configuration) {
+      this.addRule(this.currentProperty, ValidationRule[ruleName](configuration));
+      return this;
+    };
+
+    return this;
+  };
+
   return ValidationRules;
 }();
 
@@ -282,6 +318,10 @@ function url(targetOrConfig, key, descriptor) {
 
 function numericality(targetOrConfig, key, descriptor) {
   return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
+}
+
+function registerCustomValidationRule(targetOrConfig, key, descriptor) {
+  return base(targetOrConfig, key, descriptor, ValidationRule.registerCustomValidationRule);
 }
 
 var Validator = exports.Validator = function () {

--- a/dist/es2015/aurelia-validatejs.js
+++ b/dist/es2015/aurelia-validatejs.js
@@ -43,6 +43,23 @@ export let ValidationRule = class ValidationRule {
   static url(config = true) {
     return new ValidationRule('url', config);
   }
+  static registerCustomValidationRule(config = true) {
+    let ruleName = config.ruleName;
+    let rule = config.rule;
+
+    validate.validators[ruleName] = rule;
+
+    ValidationRule[ruleName] = function (config) {
+      return new ValidationRule(ruleName, config);
+    };
+
+    ValidationRules[ruleName] = function (config) {
+      this.addRule(this.currentProperty, ValidationRule[ruleName](config));
+      return this;
+    };
+
+    return new ValidationRule(ruleName, config.config || true);
+  }
 };
 
 export function cleanResult(data) {
@@ -135,6 +152,20 @@ export let ValidationRules = class ValidationRules {
     this.addRule(this.currentProperty, ValidationRule.url(configuration));
     return this;
   }
+  registerCustomValidationRule(ruleName, rule) {
+    validate.validators[ruleName] = rule;
+
+    ValidationRule[ruleName] = function (config) {
+      return new ValidationRule(ruleName, config);
+    };
+
+    this[ruleName] = function (configuration) {
+      this.addRule(this.currentProperty, ValidationRule[ruleName](configuration));
+      return this;
+    };
+
+    return this;
+  }
 };
 
 export function base(targetOrConfig, key, descriptor, rule) {
@@ -208,6 +239,9 @@ export function numericality(targetOrConfig, key, descriptor) {
   return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
 }
 
+export function registerCustomValidationRule(targetOrConfig, key, descriptor) {
+  return base(targetOrConfig, key, descriptor, ValidationRule.registerCustomValidationRule);
+}
 import validate from 'validate.js';
 
 export let Validator = class Validator {

--- a/dist/native-modules/aurelia-validatejs.js
+++ b/dist/native-modules/aurelia-validatejs.js
@@ -71,6 +71,26 @@ export var ValidationRule = function () {
     return new ValidationRule('url', config);
   };
 
+  ValidationRule.registerCustomValidationRule = function registerCustomValidationRule() {
+    var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+
+    var ruleName = config.ruleName;
+    var rule = config.rule;
+
+    validate.validators[ruleName] = rule;
+
+    ValidationRule[ruleName] = function (config) {
+      return new ValidationRule(ruleName, config);
+    };
+
+    ValidationRules[ruleName] = function (config) {
+      this.addRule(this.currentProperty, ValidationRule[ruleName](config));
+      return this;
+    };
+
+    return new ValidationRule(ruleName, config.config || true);
+  };
+
   return ValidationRule;
 }();
 
@@ -180,6 +200,21 @@ export var ValidationRules = function () {
     return this;
   };
 
+  ValidationRules.prototype.registerCustomValidationRule = function registerCustomValidationRule(ruleName, rule) {
+    validate.validators[ruleName] = rule;
+
+    ValidationRule[ruleName] = function (config) {
+      return new ValidationRule(ruleName, config);
+    };
+
+    this[ruleName] = function (configuration) {
+      this.addRule(this.currentProperty, ValidationRule[ruleName](configuration));
+      return this;
+    };
+
+    return this;
+  };
+
   return ValidationRules;
 }();
 
@@ -254,6 +289,9 @@ export function numericality(targetOrConfig, key, descriptor) {
   return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
 }
 
+export function registerCustomValidationRule(targetOrConfig, key, descriptor) {
+  return base(targetOrConfig, key, descriptor, ValidationRule.registerCustomValidationRule);
+}
 import validate from 'validate.js';
 
 export var Validator = function () {

--- a/dist/system/aurelia-validatejs.js
+++ b/dist/system/aurelia-validatejs.js
@@ -121,6 +121,12 @@ System.register(['aurelia-metadata', 'aurelia-validation', 'validate.js'], funct
 
   _export('numericality', numericality);
 
+  function registerCustomValidationRule(targetOrConfig, key, descriptor) {
+    return base(targetOrConfig, key, descriptor, ValidationRule.registerCustomValidationRule);
+  }
+
+  _export('registerCustomValidationRule', registerCustomValidationRule);
+
   function configure(config) {
     config.container.registerInstance(ValidatorInterface, new Validator());
   }
@@ -205,6 +211,26 @@ System.register(['aurelia-metadata', 'aurelia-validation', 'validate.js'], funct
           var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
           return new ValidationRule('url', config);
+        };
+
+        ValidationRule.registerCustomValidationRule = function registerCustomValidationRule() {
+          var config = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+
+          var ruleName = config.ruleName;
+          var rule = config.rule;
+
+          validate.validators[ruleName] = rule;
+
+          ValidationRule[ruleName] = function (config) {
+            return new ValidationRule(ruleName, config);
+          };
+
+          ValidationRules[ruleName] = function (config) {
+            this.addRule(this.currentProperty, ValidationRule[ruleName](config));
+            return this;
+          };
+
+          return new ValidationRule(ruleName, config.config || true);
         };
 
         return ValidationRule;
@@ -302,6 +328,21 @@ System.register(['aurelia-metadata', 'aurelia-validation', 'validate.js'], funct
 
         ValidationRules.prototype.url = function url(configuration) {
           this.addRule(this.currentProperty, ValidationRule.url(configuration));
+          return this;
+        };
+
+        ValidationRules.prototype.registerCustomValidationRule = function registerCustomValidationRule(ruleName, rule) {
+          validate.validators[ruleName] = rule;
+
+          ValidationRule[ruleName] = function (config) {
+            return new ValidationRule(ruleName, config);
+          };
+
+          this[ruleName] = function (configuration) {
+            this.addRule(this.currentProperty, ValidationRule[ruleName](configuration));
+            return this;
+          };
+
           return this;
         };
 

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -8,7 +8,7 @@ System.register(['./aurelia-validatejs'], function (_export, _context) {
       var _exportObj = {};
 
       for (var _key in _aureliaValidatejs) {
-        if (_key !== "default" && key !== "__esModule") _exportObj[_key] = _aureliaValidatejs[_key];
+        if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _aureliaValidatejs[_key];
       }
 
       _export(_exportObj);

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -48,3 +48,7 @@ export function url(targetOrConfig, key, descriptor) {
 export function numericality(targetOrConfig, key, descriptor) {
   return base(targetOrConfig, key, descriptor, ValidationRule.numericality);
 }
+
+export function registerCustomValidationRule(targetOrConfig, key, descriptor) {
+  return base(targetOrConfig, key, descriptor, ValidationRule.registerCustomValidationRule);
+}

--- a/src/validation-rule.js
+++ b/src/validation-rule.js
@@ -38,6 +38,26 @@ export class ValidationRule {
   static url(config = true) {
     return new ValidationRule('url', config);
   }
+  static registerCustomValidationRule(config = true)
+  {
+    let ruleName = config.ruleName;
+    let rule = config.rule;
+    //add the rule to validate.js
+    validate.validators[ruleName] = rule;
+    //add the wrapper for the rule to ValidationRule so we can instantiate an instance of it (as a ValidationRule object)
+    ValidationRule[ruleName] = function(config)
+    {
+        return new ValidationRule(ruleName, config);
+    }
+    //add a wrapper so we can associate the rule as a validator for a field for 
+    ValidationRules[ruleName] = function(config)
+    {
+        this.addRule(this.currentProperty, ValidationRule[ruleName](config));
+        return this;
+    };
+
+    return new ValidationRule(ruleName, config.config||true);
+  }
 }
 
 export function cleanResult(data) {

--- a/src/validation-rules.js
+++ b/src/validation-rules.js
@@ -77,4 +77,22 @@ export class ValidationRules {
     this.addRule(this.currentProperty, ValidationRule.url(configuration));
     return this;
   }
+  registerCustomValidationRule(ruleName, rule)
+  {
+  //add the custom rule's function to the  validate.js object
+    validate.validators[ruleName] = rule;
+  //add a wrapper to ValidationRule to be able to cratea an instance of the new rule.
+    ValidationRule[ruleName] = function(config)
+    {
+            return new ValidationRule(ruleName, config);
+    }
+   //Create a function to use the new validation rule using the fluent API
+    this[ruleName] = function(configuration)
+    {
+        this.addRule(this.currentProperty, ValidationRule[ruleName](configuration));
+        return this;
+    };
+
+    return this;
+  }
 }


### PR DESCRIPTION
Add ability to decorators and fluent API in aurelia-validationjs for developer
to extend validate.js with custom validation routines.

issue #4 https://github.com/aurelia/validatejs/issues/4
